### PR TITLE
feat: forward image attachments as Chat Completions multimodal (#2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codex-relay"
-version = "0.1.6"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,35 +391,7 @@ async fn handle_responses(
         req.previous_response_id
     );
 
-    if let Some(unsupported) = translate::first_unsupported_content(&req) {
-        warn!(
-            "rejecting request with unsupported content part: {}",
-            unsupported.kind
-        );
-        return unsupported_content_response(&unsupported.kind);
-    }
-
     handle_responses_inner(state, req).await
-}
-
-/// Build a Responses-API-shaped 400 for content parts the relay can't forward.
-/// Matches the OpenAI error envelope so Codex CLI surfaces the message instead
-/// of treating it as a transport failure.
-fn unsupported_content_response(kind: &str) -> Response {
-    let message = format!(
-        "codex-relay does not currently support multimodal input \
-         ({kind} content parts). Send a text-only message, or use \
-         a client that talks directly to a vision-capable provider."
-    );
-    let body = serde_json::json!({
-        "error": {
-            "message": message,
-            "type": "invalid_request_error",
-            "code": "unsupported_content",
-            "param": "input",
-        }
-    });
-    (StatusCode::BAD_REQUEST, Json(body)).into_response()
 }
 
 async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Response {
@@ -496,7 +468,7 @@ async fn handle_blocking(
                     .map(|c| c.message.clone())
                     .unwrap_or_else(|| ChatMessage {
                         role: "assistant".into(),
-                        content: Some(String::new()),
+                        content: Some(serde_json::Value::String(String::new())),
                         reasoning_content: None,
                         tool_calls: None,
                         tool_call_id: None,
@@ -589,15 +561,4 @@ mod tests {
         assert!(props.supports_parallel_tool_calls);
     }
 
-    #[test]
-    fn test_unsupported_content_response_shape() {
-        let resp = unsupported_content_response("input_image");
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-        let ct = resp
-            .headers()
-            .get(axum::http::header::CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        assert!(ct.starts_with("application/json"), "content-type: {ct}");
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod types;
 
 use anyhow::{bail, Result};
 use axum::{
-    extract::{Request, State},
+    extract::{DefaultBodyLimit, Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -91,10 +91,15 @@ async fn main() -> Result<()> {
         api_key,
     ));
 
+    // Disable axum's default 2 MiB body cap: Codex CLI may send base64-encoded
+    // image attachments that easily exceed it, and a framework-level 413 looks
+    // like a transport-layer death to Codex and crashes the session (#2).
+    // The relay only binds 127.0.0.1, so DoS isn't a concern here.
     let app = Router::new()
         .route("/v1/responses", post(handle_responses))
         .route("/v1/models", get(handle_models))
         .fallback(handle_fallback)
+        .layer(DefaultBodyLimit::disable())
         .with_state(state.clone());
 
     let addr = format!("127.0.0.1:{}", args.port);
@@ -385,7 +390,36 @@ async fn handle_responses(
         req.tools.len(),
         req.previous_response_id
     );
+
+    if let Some(unsupported) = translate::first_unsupported_content(&req) {
+        warn!(
+            "rejecting request with unsupported content part: {}",
+            unsupported.kind
+        );
+        return unsupported_content_response(&unsupported.kind);
+    }
+
     handle_responses_inner(state, req).await
+}
+
+/// Build a Responses-API-shaped 400 for content parts the relay can't forward.
+/// Matches the OpenAI error envelope so Codex CLI surfaces the message instead
+/// of treating it as a transport failure.
+fn unsupported_content_response(kind: &str) -> Response {
+    let message = format!(
+        "codex-relay does not currently support multimodal input \
+         ({kind} content parts). Send a text-only message, or use \
+         a client that talks directly to a vision-capable provider."
+    );
+    let body = serde_json::json!({
+        "error": {
+            "message": message,
+            "type": "invalid_request_error",
+            "code": "unsupported_content",
+            "param": "input",
+        }
+    });
+    (StatusCode::BAD_REQUEST, Json(body)).into_response()
 }
 
 async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Response {
@@ -553,5 +587,17 @@ mod tests {
         assert_eq!(props.max_context_window, 128_000);
         assert!(!props.supports_reasoning_summaries);
         assert!(props.supports_parallel_tool_calls);
+    }
+
+    #[test]
+    fn test_unsupported_content_response_shape() {
+        let resp = unsupported_content_response("input_image");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(ct.starts_with("application/json"), "content-type: {ct}");
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -53,7 +53,7 @@ impl SessionStore {
         if !reasoning.is_empty() {
             // Store under content-only key so lookups work even when Codex
             // replays the assistant text and function_calls as separate items.
-            let content = assistant.content.as_deref().unwrap_or("");
+            let content = assistant.text_content();
             if !content.is_empty() {
                 let key = Self::content_key(content);
                 self.turn_reasoning.insert(key, reasoning.clone());
@@ -73,7 +73,7 @@ impl SessionStore {
 
     /// Look up reasoning_content for an assistant turn by its text content.
     pub fn get_turn_reasoning(&self, _prior: &[ChatMessage], assistant: &ChatMessage) -> Option<String> {
-        let content = assistant.content.as_deref().unwrap_or("");
+        let content = assistant.text_content();
         if content.is_empty() {
             return None;
         }
@@ -123,7 +123,7 @@ mod tests {
     fn msg(role: &str, content: Option<&str>) -> ChatMessage {
         ChatMessage {
             role: role.into(),
-            content: content.map(Into::into),
+            content: content.map(|s| serde_json::Value::String(s.into())),
             reasoning_content: None,
             tool_calls: None,
             tool_call_id: None,
@@ -190,7 +190,7 @@ mod tests {
         let id = store.save(msgs.clone());
         let got = store.get_history(&id);
         assert_eq!(got.len(), 2);
-        assert_eq!(got[0].content.as_deref(), Some("hi"));
+        assert_eq!(got[0].text_content(), "hi");
 
         // save_with_id
         let id2 = store.new_id();

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -280,7 +280,7 @@ pub fn translate_stream(
             };
             let assistant_msg = ChatMessage {
                 role: "assistant".into(),
-                content: if accumulated_text.is_empty() { None } else { Some(accumulated_text.clone()) },
+                content: if accumulated_text.is_empty() { None } else { Some(serde_json::Value::String(accumulated_text.clone())) },
                 reasoning_content: if accumulated_reasoning.is_empty() { None } else { Some(accumulated_reasoning.clone()) },
                 tool_calls: assistant_tool_calls,
                 tool_call_id: None,

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -3,39 +3,6 @@ use std::collections::HashSet;
 
 use crate::{session::SessionStore, types::*};
 
-/// Content parts that the relay can't currently forward to Chat Completions.
-/// Reported up to the handler so it can return a clean 4xx instead of either
-/// silently dropping the part or letting axum's body limit kill the session
-/// (see issue #2: image attachments → 413 → unrecoverable Codex crash).
-pub struct UnsupportedContent {
-    pub kind: String,
-}
-
-/// Returns the first multimodal content part the relay does not yet translate.
-/// Today: anything tagged `input_image` or `image_url` in a message item's
-/// content array. Multimodal forwarding is a separate feature; this check
-/// exists so the handler can fail fast with an actionable error.
-pub fn first_unsupported_content(req: &ResponsesRequest) -> Option<UnsupportedContent> {
-    let items = match &req.input {
-        ResponsesInput::Messages(v) => v,
-        ResponsesInput::Text(_) => return None,
-    };
-    for item in items {
-        let Some(parts) = item.get("content").and_then(|c| c.as_array()) else {
-            continue;
-        };
-        for part in parts {
-            let kind = part.get("type").and_then(|v| v.as_str()).unwrap_or("");
-            if kind == "input_image" || kind == "image_url" {
-                return Some(UnsupportedContent {
-                    kind: kind.to_string(),
-                });
-            }
-        }
-    }
-    None
-}
-
 /// Convert a Responses API request + prior history into a Chat Completions request.
 pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessions: &SessionStore) -> ChatRequest {
     let mut messages = history;
@@ -48,7 +15,7 @@ pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessio
                 0,
                 ChatMessage {
                     role: "system".into(),
-                    content: Some(system.clone()),
+                    content: Some(Value::String(system.clone())),
                     reasoning_content: None,
                     tool_calls: None,
                     tool_call_id: None,
@@ -63,7 +30,7 @@ pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessio
         ResponsesInput::Text(text) => {
             messages.push(ChatMessage {
                 role: "user".into(),
-                content: Some(text.clone()),
+                content: Some(Value::String(text.clone())),
                 reasoning_content: None,
                 tool_calls: None,
                 tool_call_id: None,
@@ -159,7 +126,7 @@ pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessio
                             let output  = item.get("output").and_then(|v| v.as_str()).unwrap_or("");
                             messages.push(ChatMessage {
                                 role: "tool".into(),
-                                content: Some(output.to_string()),
+                                content: Some(Value::String(output.to_string())),
                                 reasoning_content: None,
                                 tool_calls: None,
                                 tool_call_id: Some(call_id.to_string()),
@@ -180,10 +147,9 @@ pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessio
                                 other => other,
                             }
                             .to_string();
-                            let content = value_to_text(item.get("content"));
                             let mut msg = ChatMessage {
                                 role,
-                                content: Some(content),
+                                content: value_to_chat_content(item.get("content")),
                                 reasoning_content: None,
                                 tool_calls: None,
                                 tool_call_id: None,
@@ -276,7 +242,7 @@ pub fn from_chat_response(
     let choice = chat.choices.into_iter().next().unwrap_or_else(|| ChatChoice {
         message: ChatMessage {
             role: "assistant".into(),
-            content: Some(String::new()),
+            content: Some(Value::String(String::new())),
             reasoning_content: None,
             tool_calls: None,
             tool_call_id: None,
@@ -284,7 +250,7 @@ pub fn from_chat_response(
         },
     });
 
-    let text = choice.message.content.clone().unwrap_or_default();
+    let text = choice.message.text_content().to_string();
     let usage = chat.usage.unwrap_or(ChatUsage {
         prompt_tokens: 0,
         completion_tokens: 0,
@@ -313,17 +279,74 @@ pub fn from_chat_response(
     (response, vec![choice.message])
 }
 
-/// Collapse a Responses API content value (string or parts array) to plain text.
-fn value_to_text(v: Option<&Value>) -> String {
+/// Translate a Responses-API `content` value to its Chat Completions equivalent.
+///
+/// - Plain string → `Value::String`.
+/// - Parts array containing only text → collapsed to `Value::String` (the
+///   shape Chat Completions expects in the common text-only case, and the
+///   shape session.rs's reasoning fingerprint compares against).
+/// - Parts array with any non-text part (e.g. `input_image`) → kept as a
+///   `Value::Array` of multimodal Chat Completions parts:
+///     * `input_text` / `text`  → `{type:"text", text}`
+///     * `input_image` (string) → `{type:"image_url", image_url:{url}}`
+///     * `image_url`            → normalized to `{type:"image_url", image_url:{url}}`
+///   Unknown part types pass through; the upstream may reject them and the
+///   relay propagates that error as-is.
+fn value_to_chat_content(v: Option<&Value>) -> Option<Value> {
     match v {
-        None => String::new(),
-        Some(Value::String(s)) => s.clone(),
-        Some(Value::Array(parts)) => parts
-            .iter()
-            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
-            .collect::<Vec<_>>()
-            .join(""),
-        Some(other) => other.to_string(),
+        None => None,
+        Some(Value::String(s)) => Some(Value::String(s.clone())),
+        Some(Value::Array(parts)) => {
+            // `output_text` is what Codex replays for assistant history items;
+            // treat it the same as text for the purposes of collapsing.
+            let has_non_text = parts.iter().any(|p| {
+                let kind = p.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                !matches!(kind, "input_text" | "text" | "output_text")
+            });
+            if !has_non_text {
+                let s: String = parts
+                    .iter()
+                    .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+                    .collect::<Vec<_>>()
+                    .join("");
+                Some(Value::String(s))
+            } else {
+                let mapped: Vec<Value> = parts.iter().map(map_content_part).collect();
+                Some(Value::Array(mapped))
+            }
+        }
+        Some(other) => Some(Value::String(other.to_string())),
+    }
+}
+
+/// Reshape a single Responses-API content part into a Chat Completions one.
+fn map_content_part(part: &Value) -> Value {
+    let kind = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    match kind {
+        "input_text" | "text" | "output_text" => {
+            let text = part.get("text").and_then(|t| t.as_str()).unwrap_or("");
+            json!({"type": "text", "text": text})
+        }
+        "input_image" => {
+            // Responses API: image_url is a plain string (often a data: URL).
+            // Chat Completions wants it wrapped in an object.
+            let url = part
+                .get("image_url")
+                .and_then(|u| u.as_str())
+                .unwrap_or("");
+            json!({"type": "image_url", "image_url": {"url": url}})
+        }
+        "image_url" => {
+            // Either already-Chat-Completions-shaped (image_url is an object)
+            // or a Responses-style flat url; normalize both.
+            let inner = match part.get("image_url") {
+                Some(Value::Object(_)) => part.get("image_url").cloned().unwrap_or(Value::Null),
+                Some(Value::String(s)) => json!({"url": s}),
+                _ => json!({"url": ""}),
+            };
+            json!({"type": "image_url", "image_url": inner})
+        }
+        _ => part.clone(),
     }
 }
 
@@ -353,7 +376,7 @@ mod tests {
         let chat = to_chat_request(&req, vec![], &sessions);
         assert_eq!(chat.messages.len(), 1);
         assert_eq!(chat.messages[0].role, "user");
-        assert_eq!(chat.messages[0].content.as_deref(), Some("hello"));
+        assert_eq!(chat.messages[0].text_content(), "hello");
     }
 
     #[test]
@@ -363,7 +386,7 @@ mod tests {
         req.instructions = Some("be helpful".into());
         let chat = to_chat_request(&req, vec![], &sessions);
         assert_eq!(chat.messages[0].role, "system");
-        assert_eq!(chat.messages[0].content.as_deref(), Some("be helpful"));
+        assert_eq!(chat.messages[0].text_content(), "be helpful");
     }
 
     #[test]
@@ -374,7 +397,7 @@ mod tests {
         ]));
         let chat = to_chat_request(&req, vec![], &sessions);
         assert_eq!(chat.messages[0].role, "system");
-        assert_eq!(chat.messages[0].content.as_deref(), Some("secret instructions"));
+        assert_eq!(chat.messages[0].text_content(), "secret instructions");
     }
 
     #[test]
@@ -401,7 +424,7 @@ mod tests {
         ]));
         let chat = to_chat_request(&req, vec![], &sessions);
         assert_eq!(chat.messages[0].role, "tool");
-        assert_eq!(chat.messages[0].content.as_deref(), Some("result"));
+        assert_eq!(chat.messages[0].text_content(), "result");
         assert_eq!(chat.messages[0].tool_call_id.as_deref(), Some("c1"));
     }
 
@@ -436,45 +459,65 @@ mod tests {
             json!({"type": "message", "role": "user", "content": "plain text"}),
         ]));
         let chat = to_chat_request(&req, vec![], &sessions);
-        assert_eq!(chat.messages[0].content.as_deref(), Some("plain text"));
+        assert_eq!(chat.messages[0].text_content(), "plain text");
     }
 
+    /// input_image (Responses API) + input_text → Chat Completions
+    /// multimodal content array with image_url wrapped in {url:...}.
     #[test]
-    fn test_first_unsupported_content_flags_input_image() {
+    fn test_input_image_becomes_multimodal_content() {
+        let sessions = SessionStore::new();
         let req = base_req(ResponsesInput::Messages(vec![
             json!({"type": "message", "role": "user", "content": [
                 {"type": "input_text", "text": "what is this?"},
                 {"type": "input_image", "image_url": "data:image/png;base64,AAA"}
             ]}),
         ]));
-        let hit = first_unsupported_content(&req).expect("should detect image");
-        assert_eq!(hit.kind, "input_image");
+        let chat = to_chat_request(&req, vec![], &sessions);
+        let parts = chat.messages[0]
+            .content
+            .as_ref()
+            .and_then(|v| v.as_array())
+            .expect("content must be a parts array when an image is present");
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[0]["text"], "what is this?");
+        assert_eq!(parts[1]["type"], "image_url");
+        assert_eq!(parts[1]["image_url"]["url"], "data:image/png;base64,AAA");
     }
 
+    /// Chat-Completions-style image_url passes through normalized.
     #[test]
-    fn test_first_unsupported_content_flags_chat_style_image_url() {
+    fn test_chat_style_image_url_passes_through() {
+        let sessions = SessionStore::new();
         let req = base_req(ResponsesInput::Messages(vec![
             json!({"type": "message", "role": "user", "content": [
                 {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}}
             ]}),
         ]));
-        assert!(first_unsupported_content(&req).is_some());
+        let chat = to_chat_request(&req, vec![], &sessions);
+        let parts = chat.messages[0]
+            .content
+            .as_ref()
+            .and_then(|v| v.as_array())
+            .expect("multimodal content");
+        assert_eq!(parts[0]["type"], "image_url");
+        assert_eq!(parts[0]["image_url"]["url"], "https://example.com/x.png");
     }
 
+    /// Text-only content arrays must still collapse to a plain string —
+    /// session.rs fingerprints assistant turns on the string form.
     #[test]
-    fn test_first_unsupported_content_text_only_is_none() {
+    fn test_text_only_parts_collapse_to_string() {
+        let sessions = SessionStore::new();
         let req = base_req(ResponsesInput::Messages(vec![
             json!({"type": "message", "role": "user", "content": [
                 {"type": "input_text", "text": "hi"}
             ]}),
         ]));
-        assert!(first_unsupported_content(&req).is_none());
-    }
-
-    #[test]
-    fn test_first_unsupported_content_plain_text_input_is_none() {
-        let req = base_req(ResponsesInput::Text("hi".into()));
-        assert!(first_unsupported_content(&req).is_none());
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert!(chat.messages[0].content.as_ref().unwrap().is_string());
+        assert_eq!(chat.messages[0].text_content(), "hi");
     }
 
     #[test]
@@ -487,7 +530,7 @@ mod tests {
             ]}),
         ]));
         let chat = to_chat_request(&req, vec![], &sessions);
-        assert_eq!(chat.messages[0].content.as_deref(), Some("hello world"));
+        assert_eq!(chat.messages[0].text_content(), "hello world");
     }
 
     // ── Deduplication tests ────────────────────────────────────────────

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -3,6 +3,39 @@ use std::collections::HashSet;
 
 use crate::{session::SessionStore, types::*};
 
+/// Content parts that the relay can't currently forward to Chat Completions.
+/// Reported up to the handler so it can return a clean 4xx instead of either
+/// silently dropping the part or letting axum's body limit kill the session
+/// (see issue #2: image attachments → 413 → unrecoverable Codex crash).
+pub struct UnsupportedContent {
+    pub kind: String,
+}
+
+/// Returns the first multimodal content part the relay does not yet translate.
+/// Today: anything tagged `input_image` or `image_url` in a message item's
+/// content array. Multimodal forwarding is a separate feature; this check
+/// exists so the handler can fail fast with an actionable error.
+pub fn first_unsupported_content(req: &ResponsesRequest) -> Option<UnsupportedContent> {
+    let items = match &req.input {
+        ResponsesInput::Messages(v) => v,
+        ResponsesInput::Text(_) => return None,
+    };
+    for item in items {
+        let Some(parts) = item.get("content").and_then(|c| c.as_array()) else {
+            continue;
+        };
+        for part in parts {
+            let kind = part.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            if kind == "input_image" || kind == "image_url" {
+                return Some(UnsupportedContent {
+                    kind: kind.to_string(),
+                });
+            }
+        }
+    }
+    None
+}
+
 /// Convert a Responses API request + prior history into a Chat Completions request.
 pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessions: &SessionStore) -> ChatRequest {
     let mut messages = history;
@@ -404,6 +437,44 @@ mod tests {
         ]));
         let chat = to_chat_request(&req, vec![], &sessions);
         assert_eq!(chat.messages[0].content.as_deref(), Some("plain text"));
+    }
+
+    #[test]
+    fn test_first_unsupported_content_flags_input_image() {
+        let req = base_req(ResponsesInput::Messages(vec![
+            json!({"type": "message", "role": "user", "content": [
+                {"type": "input_text", "text": "what is this?"},
+                {"type": "input_image", "image_url": "data:image/png;base64,AAA"}
+            ]}),
+        ]));
+        let hit = first_unsupported_content(&req).expect("should detect image");
+        assert_eq!(hit.kind, "input_image");
+    }
+
+    #[test]
+    fn test_first_unsupported_content_flags_chat_style_image_url() {
+        let req = base_req(ResponsesInput::Messages(vec![
+            json!({"type": "message", "role": "user", "content": [
+                {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}}
+            ]}),
+        ]));
+        assert!(first_unsupported_content(&req).is_some());
+    }
+
+    #[test]
+    fn test_first_unsupported_content_text_only_is_none() {
+        let req = base_req(ResponsesInput::Messages(vec![
+            json!({"type": "message", "role": "user", "content": [
+                {"type": "input_text", "text": "hi"}
+            ]}),
+        ]));
+        assert!(first_unsupported_content(&req).is_none());
+    }
+
+    #[test]
+    fn test_first_unsupported_content_plain_text_input_is_none() {
+        let req = base_req(ResponsesInput::Text("hi".into()));
+        assert!(first_unsupported_content(&req).is_none());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -83,7 +83,11 @@ pub struct ChatRequest {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ChatMessage {
     pub role: String,
-    pub content: Option<String>,
+    /// Either a plain string (the common case) or a multimodal content-parts
+    /// array (`[{type:"text",...}, {type:"image_url",...}]`). Modeled as a raw
+    /// JSON Value so both shapes pass through serde transparently. Use
+    /// [`ChatMessage::text_content`] when you only care about the text.
+    pub content: Option<Value>,
     /// Reasoning/thinking content emitted by models like kimi-k2.6.
     /// Must be round-tripped back when replaying tool call history.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -94,6 +98,18 @@ pub struct ChatMessage {
     pub tool_call_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+}
+
+impl ChatMessage {
+    /// Best-effort plain-text view of `content`. Returns `""` for missing,
+    /// non-string, or multimodal payloads — callers that care about the
+    /// multimodal parts should look at `content` directly.
+    pub fn text_content(&self) -> &str {
+        self.content
+            .as_ref()
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/tests/compat_codex_0_128.rs
+++ b/tests/compat_codex_0_128.rs
@@ -81,9 +81,45 @@ fn reasoning_input_items_are_dropped() {
     let texts: Vec<&str> = chat
         .messages
         .iter()
-        .map(|m| m.content.as_deref().unwrap_or(""))
+        .map(|m| m.text_content())
         .collect();
     assert_eq!(texts, ["system", "first turn", "second turn"]);
+}
+
+/// Codex 0.128 sends image attachments as `input_image` content parts with a
+/// flat `image_url` string. The relay must translate these into the Chat
+/// Completions multimodal shape (content as an array containing `image_url`
+/// parts wrapped in `{url}`) so vision-capable upstreams (e.g. DeepSeek V4
+/// Pro) can receive them. Locks in the wire-shape contract verified live in
+/// `compat_deepseek_live.rs::live_deepseek_v4_pro_image_input_wire_shape`.
+#[test]
+fn input_image_becomes_chat_completions_multimodal() {
+    let req = fixture("with_image_input.json");
+    let chat = to_chat_request(&req, Vec::new(), &SessionStore::new());
+
+    // messages[0] = system (from `instructions`), messages[1] = user with image.
+    assert_eq!(chat.messages.len(), 2);
+    assert_eq!(chat.messages[0].role, "system");
+    assert_eq!(chat.messages[1].role, "user");
+
+    let parts = chat.messages[1]
+        .content
+        .as_ref()
+        .and_then(Value::as_array)
+        .expect("user content must be a multimodal array");
+    assert_eq!(parts.len(), 2, "parts: {parts:?}");
+
+    assert_eq!(parts[0]["type"], "text");
+    assert_eq!(parts[0]["text"], "What is in this image?");
+
+    assert_eq!(parts[1]["type"], "image_url");
+    let url = parts[1]["image_url"]["url"]
+        .as_str()
+        .expect("image_url.url must be a string (Chat Completions shape)");
+    assert!(
+        url.starts_with("data:image/png;base64,"),
+        "url not a data URL: {url}"
+    );
 }
 
 #[test]

--- a/tests/compat_deepseek_live.rs
+++ b/tests/compat_deepseek_live.rs
@@ -712,3 +712,127 @@ async fn live_deepseek_v4_pro_reasoning_round_trip() {
         .map(|s| s.contains("Beijing"))
         .unwrap_or(false));
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// Test 6: multimodal image input on deepseek-v4-pro.
+//
+// Codex sends `input_image` content parts; the relay must translate them into
+// Chat Completions `image_url` parts so vision-capable upstreams (DeepSeek V4
+// Pro) can actually see the image. Before this test existed, image attachments
+// either crashed Codex with 413 or got silently dropped (#2).
+//
+// We send a tiny inline PNG (1×1 red pixel) so the test doesn't depend on
+// external image hosting. We only assert that the request succeeds and the
+// assistant returns non-empty text — we don't assert the *content* of the
+// description because that's model-dependent. The point is to lock in that
+// the relay's wire shape is acceptable to DeepSeek's vision pipeline.
+// ────────────────────────────────────────────────────────────────────────────
+
+/// 1×1 red PNG, base64-encoded. Tiny but valid; enough to exercise the
+/// vision input path without bloating fixtures.
+const TINY_RED_PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+fn image_input_body(model: &str, stream: bool) -> Value {
+    let data_url = format!("data:image/png;base64,{TINY_RED_PNG_B64}");
+    json!({
+        "model": model,
+        "instructions": "Answer in one short sentence.",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Describe the attached image briefly."},
+                {"type": "input_image", "image_url": data_url}
+            ]
+        }],
+        "tools": [],
+        "tool_choice": "auto",
+        "parallel_tool_calls": false,
+        "store": false,
+        "stream": stream,
+        "include": []
+    })
+}
+
+#[tokio::test]
+#[ignore]
+async fn live_deepseek_v4_pro_image_input_blocking() {
+    let Some(key) = need_key() else { return };
+    let relay = Relay::spawn(DEEPSEEK_UPSTREAM, &key);
+
+    let resp: Value = reqwest::Client::new()
+        .post(relay.url("/v1/responses"))
+        .json(&image_input_body("deepseek-v4-pro", false))
+        .send()
+        .await
+        .expect("POST /v1/responses")
+        .error_for_status()
+        .expect("non-2xx (relay forwarded an unhappy upstream)")
+        .json()
+        .await
+        .expect("json decode");
+
+    assert_eq!(resp["object"].as_str(), Some("response"));
+    let output = resp["output"].as_array().expect("output array");
+    assert!(!output.is_empty(), "empty output: {resp}");
+    let text = output[0]["content"][0]["text"]
+        .as_str()
+        .expect("output_text present");
+    assert!(
+        !text.trim().is_empty(),
+        "vision model returned empty text — relay likely dropped the image: {resp}"
+    );
+    eprintln!("✓ v4-pro vision blocking output ({} chars): {text}", text.len());
+}
+
+/// Captures the relay's outbound Chat Completions body via a recording proxy
+/// and asserts it is multimodal-shaped (content is an array containing an
+/// `image_url` part). This is the test that locks in the wire-shape contract:
+/// if the relay ever regresses to dropping the image or sending a string
+/// content, this will fail without needing the model to "say the right thing".
+#[tokio::test]
+#[ignore]
+async fn live_deepseek_v4_pro_image_input_wire_shape() {
+    let Some(key) = need_key() else { return };
+
+    let (proxy_port, recorded_bodies) =
+        spawn_recording_proxy("https://api.deepseek.com", &key).await;
+    let proxy_upstream = format!("http://127.0.0.1:{proxy_port}/v1");
+    let relay = Relay::spawn(&proxy_upstream, &key);
+
+    let resp = reqwest::Client::new()
+        .post(relay.url("/v1/responses"))
+        .json(&image_input_body("deepseek-v4-pro", false))
+        .send()
+        .await
+        .expect("POST")
+        .error_for_status()
+        .expect("non-2xx");
+    let _: Value = resp.json().await.expect("json decode");
+
+    let bodies = recorded_bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 1, "expected exactly 1 chat-completions POST");
+    let body: Value = serde_json::from_slice(&bodies[0]).expect("body json");
+    let user = body["messages"]
+        .as_array()
+        .expect("messages")
+        .iter()
+        .find(|m| m["role"].as_str() == Some("user"))
+        .expect("user message");
+
+    let parts = user["content"]
+        .as_array()
+        .expect("user content must be a multimodal array (got non-array)");
+    let has_text = parts
+        .iter()
+        .any(|p| p["type"].as_str() == Some("text") && p["text"].as_str().is_some());
+    let has_image = parts.iter().any(|p| {
+        p["type"].as_str() == Some("image_url")
+            && p["image_url"]["url"]
+                .as_str()
+                .map(|s| s.starts_with("data:image/png;base64,"))
+                .unwrap_or(false)
+    });
+    assert!(has_text, "missing text part: {parts:?}");
+    assert!(has_image, "missing image_url part: {parts:?}");
+}

--- a/tests/compat_deepseek_live.rs
+++ b/tests/compat_deepseek_live.rs
@@ -714,25 +714,29 @@ async fn live_deepseek_v4_pro_reasoning_round_trip() {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Test 6: multimodal image input on deepseek-v4-pro.
+// Test 6: multimodal image-input wire shape, verified live.
 //
-// Codex sends `input_image` content parts; the relay must translate them into
-// Chat Completions `image_url` parts so vision-capable upstreams (DeepSeek V4
-// Pro) can actually see the image. Before this test existed, image attachments
-// either crashed Codex with 413 or got silently dropped (#2).
+// Empirically confirmed 2026-05-11: DeepSeek's Chat Completions API does NOT
+// accept any multimodal content part variant — it returns
+//   400 invalid_request_error: "unknown variant `image_url`, expected `text`"
+// for `image_url`, `input_image`, and `image` alike. So we can't do an
+// end-to-end happy-path image test against DeepSeek today.
 //
-// We send a tiny inline PNG (1×1 red pixel) so the test doesn't depend on
-// external image hosting. We only assert that the request succeeds and the
-// assistant returns non-empty text — we don't assert the *content* of the
-// description because that's model-dependent. The point is to lock in that
-// the relay's wire shape is acceptable to DeepSeek's vision pipeline.
+// What we *can* lock in live, however, is that codex-relay's outbound Chat
+// Completions body has the right OpenAI-standard multimodal shape, so the
+// moment DeepSeek (or any other provider in the supported list) enables
+// vision, codex-relay users get it for free without further changes.
+//
+// We use a recording proxy in front of DeepSeek that captures the outbound
+// body BEFORE forwarding. The relay's translation is asserted on the
+// captured body; the upstream's eventual 400 is expected and ignored.
 // ────────────────────────────────────────────────────────────────────────────
 
 /// 1×1 red PNG, base64-encoded. Tiny but valid; enough to exercise the
 /// vision input path without bloating fixtures.
 const TINY_RED_PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
 
-fn image_input_body(model: &str, stream: bool) -> Value {
+fn image_input_body(model: &str) -> Value {
     let data_url = format!("data:image/png;base64,{TINY_RED_PNG_B64}");
     json!({
         "model": model,
@@ -749,47 +753,15 @@ fn image_input_body(model: &str, stream: bool) -> Value {
         "tool_choice": "auto",
         "parallel_tool_calls": false,
         "store": false,
-        "stream": stream,
+        "stream": false,
         "include": []
     })
 }
 
-#[tokio::test]
-#[ignore]
-async fn live_deepseek_v4_pro_image_input_blocking() {
-    let Some(key) = need_key() else { return };
-    let relay = Relay::spawn(DEEPSEEK_UPSTREAM, &key);
-
-    let resp: Value = reqwest::Client::new()
-        .post(relay.url("/v1/responses"))
-        .json(&image_input_body("deepseek-v4-pro", false))
-        .send()
-        .await
-        .expect("POST /v1/responses")
-        .error_for_status()
-        .expect("non-2xx (relay forwarded an unhappy upstream)")
-        .json()
-        .await
-        .expect("json decode");
-
-    assert_eq!(resp["object"].as_str(), Some("response"));
-    let output = resp["output"].as_array().expect("output array");
-    assert!(!output.is_empty(), "empty output: {resp}");
-    let text = output[0]["content"][0]["text"]
-        .as_str()
-        .expect("output_text present");
-    assert!(
-        !text.trim().is_empty(),
-        "vision model returned empty text — relay likely dropped the image: {resp}"
-    );
-    eprintln!("✓ v4-pro vision blocking output ({} chars): {text}", text.len());
-}
-
-/// Captures the relay's outbound Chat Completions body via a recording proxy
-/// and asserts it is multimodal-shaped (content is an array containing an
-/// `image_url` part). This is the test that locks in the wire-shape contract:
-/// if the relay ever regresses to dropping the image or sending a string
-/// content, this will fail without needing the model to "say the right thing".
+/// Recording-proxy live test: send a Codex-shaped `input_image` request,
+/// inspect what the relay forwarded upstream, assert it's multimodal-shaped.
+/// We don't require the upstream to return 2xx — DeepSeek currently 400s on
+/// any image, and that's a property of *their* API, not the relay's.
 #[tokio::test]
 #[ignore]
 async fn live_deepseek_v4_pro_image_input_wire_shape() {
@@ -800,15 +772,15 @@ async fn live_deepseek_v4_pro_image_input_wire_shape() {
     let proxy_upstream = format!("http://127.0.0.1:{proxy_port}/v1");
     let relay = Relay::spawn(&proxy_upstream, &key);
 
-    let resp = reqwest::Client::new()
+    // Fire and forget — don't unwrap the status. The relay forwards whatever
+    // DeepSeek returns (200 if/when they support vision, 400 today). Either
+    // way the recording proxy has already captured what we sent.
+    let _ = reqwest::Client::new()
         .post(relay.url("/v1/responses"))
-        .json(&image_input_body("deepseek-v4-pro", false))
+        .json(&image_input_body("deepseek-v4-pro"))
         .send()
         .await
-        .expect("POST")
-        .error_for_status()
-        .expect("non-2xx");
-    let _: Value = resp.json().await.expect("json decode");
+        .expect("POST");
 
     let bodies = recorded_bodies.lock().unwrap();
     assert_eq!(bodies.len(), 1, "expected exactly 1 chat-completions POST");
@@ -835,4 +807,36 @@ async fn live_deepseek_v4_pro_image_input_wire_shape() {
     });
     assert!(has_text, "missing text part: {parts:?}");
     assert!(has_image, "missing image_url part: {parts:?}");
+    eprintln!("✓ outbound multimodal shape verified ({} parts)", parts.len());
+}
+
+/// Companion to the wire-shape test: confirm the symptom of DeepSeek's
+/// current vision-input rejection so we can spot the day they enable it.
+/// When this test starts FAILING (i.e. DeepSeek stops 400'ing on image_url),
+/// flip it into a proper happy-path test.
+#[tokio::test]
+#[ignore]
+async fn live_deepseek_v4_pro_image_input_currently_rejected_by_upstream() {
+    let Some(key) = need_key() else { return };
+    let relay = Relay::spawn(DEEPSEEK_UPSTREAM, &key);
+
+    let resp = reqwest::Client::new()
+        .post(relay.url("/v1/responses"))
+        .json(&image_input_body("deepseek-v4-pro"))
+        .send()
+        .await
+        .expect("POST");
+
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+
+    // As of 2026-05-11 DeepSeek's Chat Completions deserializer rejects every
+    // image content-part variant with this exact message. If that ever stops
+    // being true, this assertion fires and we know vision support landed.
+    assert!(
+        status == reqwest::StatusCode::BAD_REQUEST
+            && body.contains("unknown variant")
+            && body.contains("image_url"),
+        "DeepSeek may have enabled vision input — status={status}, body={body}"
+    );
 }

--- a/tests/compat_deepseek_v4_pro.rs
+++ b/tests/compat_deepseek_v4_pro.rs
@@ -71,7 +71,7 @@ fn test_deepseek_v4_pro_reasoning_roundtrip_text_only() {
     // messages[2] = user "Continue"
     assert_eq!(chat.messages.len(), 3);
     assert_eq!(chat.messages[1].role, "assistant");
-    assert_eq!(chat.messages[1].content.as_deref(), Some("Let me analyze this"));
+    assert_eq!(chat.messages[1].text_content(), "Let me analyze this");
     assert_eq!(
         chat.messages[1].reasoning_content.as_deref(),
         Some("<think>analyzing the problem...</think>"),
@@ -122,7 +122,7 @@ fn test_deepseek_v4_pro_reasoning_roundtrip_with_tool_calls() {
 
     // Assistant TEXT message should have reasoning_content
     assert_eq!(chat.messages[1].role, "assistant");
-    assert_eq!(chat.messages[1].content.as_deref(), Some("Let me check"));
+    assert_eq!(chat.messages[1].text_content(), "Let me check");
     assert_eq!(
         chat.messages[1].reasoning_content.as_deref(),
         Some("<think>need to read files</think>"),
@@ -168,7 +168,7 @@ fn test_deepseek_v4_pro_multi_turn_reasoning() {
 
     // Turn 1 assistant
     assert_eq!(chat.messages[1].role, "assistant");
-    assert_eq!(chat.messages[1].content.as_deref(), Some("Step 1 analysis"));
+    assert_eq!(chat.messages[1].text_content(), "Step 1 analysis");
     assert_eq!(
         chat.messages[1].reasoning_content.as_deref(),
         Some("<think>first pass thinking</think>"),
@@ -177,7 +177,7 @@ fn test_deepseek_v4_pro_multi_turn_reasoning() {
 
     // Turn 2 assistant
     assert_eq!(chat.messages[3].role, "assistant");
-    assert_eq!(chat.messages[3].content.as_deref(), Some("Step 2 deeper look"));
+    assert_eq!(chat.messages[3].text_content(), "Step 2 deeper look");
     assert_eq!(
         chat.messages[3].reasoning_content.as_deref(),
         Some("<think>second pass thinking</think>"),
@@ -203,7 +203,7 @@ fn test_non_thinking_model_no_reasoning_content() {
 
     assert_eq!(chat.messages.len(), 3);
     assert_eq!(chat.messages[1].role, "assistant");
-    assert_eq!(chat.messages[1].content.as_deref(), Some("Hi there!"));
+    assert_eq!(chat.messages[1].text_content(), "Hi there!");
     assert!(
         chat.messages[1].reasoning_content.is_none(),
         "non-thinking model should have reasoning_content=None"

--- a/tests/compat_kimi_live.rs
+++ b/tests/compat_kimi_live.rs
@@ -1,0 +1,191 @@
+//! Live image-input tests against the real Kimi (Moonshot) API.
+//!
+//! Empirically confirmed 2026-05-11: `kimi-k2.6` and `moonshot-v1-*-vision-*`
+//! accept the standard OpenAI Chat Completions multimodal shape (content as a
+//! parts array containing `{type:"image_url", image_url:{url}}`). DeepSeek
+//! V4 Pro does not (see `compat_deepseek_live.rs::..._currently_rejected_*`),
+//! so Kimi is currently our happy-path live verification for image forwarding.
+//!
+//! Gated on `MOONSHOT_API_KEY`. Each test is `#[ignore]`'d so the default
+//! `cargo test` stays offline:
+//!
+//!     MOONSHOT_API_KEY=sk-... cargo test --test compat_kimi_live -- --ignored --test-threads=1
+
+use serde_json::{json, Value};
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const RELAY_BIN: &str = env!("CARGO_BIN_EXE_codex-relay");
+const KIMI_UPSTREAM: &str = "https://api.moonshot.cn/v1";
+
+/// 1×1 red PNG, base64-encoded. Tiny but valid; same fixture as the
+/// DeepSeek wire-shape test for consistency.
+const TINY_RED_PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+fn moonshot_key() -> Option<String> {
+    std::env::var("MOONSHOT_API_KEY").ok().filter(|s| !s.is_empty())
+}
+
+fn need_key() -> Option<String> {
+    match moonshot_key() {
+        Some(k) => Some(k),
+        None => {
+            eprintln!("skip: MOONSHOT_API_KEY not set");
+            None
+        }
+    }
+}
+
+fn pick_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().unwrap().port();
+    drop(l);
+    p
+}
+
+struct Relay {
+    child: Child,
+    port: u16,
+}
+
+impl Drop for Relay {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Relay {
+    fn spawn(upstream: &str, key: &str) -> Self {
+        let port = pick_port();
+        let child = Command::new(RELAY_BIN)
+            .env("CODEX_RELAY_PORT", port.to_string())
+            .env("CODEX_RELAY_UPSTREAM", upstream)
+            .env("CODEX_RELAY_API_KEY", key)
+            .env("RUST_LOG", "codex_relay=warn")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn codex-relay");
+
+        let mut handle = Relay { child, port };
+        handle.wait_ready();
+        handle
+    }
+
+    fn wait_ready(&mut self) {
+        let deadline = Instant::now() + Duration::from_secs(8);
+        while Instant::now() < deadline {
+            if std::net::TcpStream::connect(("127.0.0.1", self.port)).is_ok() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(80));
+        }
+        panic!("relay did not become ready on :{}", self.port);
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{}", self.port, path)
+    }
+}
+
+fn image_input_body(model: &str) -> Value {
+    let data_url = format!("data:image/png;base64,{TINY_RED_PNG_B64}");
+    json!({
+        "model": model,
+        "instructions": "Answer in one short sentence.",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "What do you see in this image? One short sentence."},
+                {"type": "input_image", "image_url": data_url}
+            ]
+        }],
+        "tools": [],
+        "tool_choice": "auto",
+        "parallel_tool_calls": false,
+        "store": false,
+        "stream": false,
+        "include": []
+    })
+}
+
+/// End-to-end happy path: a Codex-shaped `input_image` request goes through
+/// the relay, hits the real Kimi-K2.6 vision endpoint, and comes back with
+/// non-empty assistant text. Locks in that the relay's translation is
+/// accepted by a real vision-capable upstream.
+#[tokio::test]
+#[ignore]
+async fn live_kimi_k2_6_image_input_blocking() {
+    let Some(key) = need_key() else { return };
+    let relay = Relay::spawn(KIMI_UPSTREAM, &key);
+
+    let resp: Value = reqwest::Client::new()
+        .post(relay.url("/v1/responses"))
+        .json(&image_input_body("kimi-k2.6"))
+        .send()
+        .await
+        .expect("POST /v1/responses")
+        .error_for_status()
+        .expect("non-2xx (relay forwarded an unhappy upstream)")
+        .json()
+        .await
+        .expect("json decode");
+
+    assert_eq!(resp["object"].as_str(), Some("response"));
+    assert_eq!(resp["model"].as_str(), Some("kimi-k2.6"));
+    let output = resp["output"].as_array().expect("output array");
+    assert!(!output.is_empty(), "empty output: {resp}");
+
+    let text = output[0]["content"][0]["text"]
+        .as_str()
+        .expect("output_text present");
+    assert!(
+        !text.trim().is_empty(),
+        "vision model returned empty text — relay likely dropped the image: {resp}"
+    );
+
+    let usage = &resp["usage"];
+    assert!(
+        usage["input_tokens"].as_u64().unwrap_or(0) > 0,
+        "input_tokens: {usage}"
+    );
+    assert!(
+        usage["output_tokens"].as_u64().unwrap_or(0) > 0,
+        "output_tokens: {usage}"
+    );
+
+    eprintln!("✓ kimi-k2.6 vision response ({} chars): {text}", text.len());
+}
+
+/// Same as above but against the dedicated vision preview model, so we have
+/// a backup pin in case the K2.6 generation rotates / changes behavior.
+#[tokio::test]
+#[ignore]
+async fn live_kimi_v1_vision_preview_image_input_blocking() {
+    let Some(key) = need_key() else { return };
+    let relay = Relay::spawn(KIMI_UPSTREAM, &key);
+
+    let resp: Value = reqwest::Client::new()
+        .post(relay.url("/v1/responses"))
+        .json(&image_input_body("moonshot-v1-32k-vision-preview"))
+        .send()
+        .await
+        .expect("POST /v1/responses")
+        .error_for_status()
+        .expect("non-2xx")
+        .json()
+        .await
+        .expect("json decode");
+
+    let text = resp["output"][0]["content"][0]["text"]
+        .as_str()
+        .expect("output_text present");
+    assert!(!text.trim().is_empty(), "empty: {resp}");
+    eprintln!(
+        "✓ moonshot-v1-32k-vision-preview ({} chars): {text}",
+        text.len()
+    );
+}

--- a/tests/fixtures/VERSIONS.md
+++ b/tests/fixtures/VERSIONS.md
@@ -34,6 +34,26 @@ Live tests gated by `DEEPSEEK_API_KEY` env var. Run with:
 DEEPSEEK_API_KEY=sk-... cargo test --test compat_deepseek_live -- --ignored
 ```
 
+Note: as of 2026-05-11 DeepSeek's Chat Completions endpoint does **not**
+accept multimodal image content parts — it rejects `image_url`, `input_image`,
+and `image` with `"unknown variant ..., expected text"`. Image-input wire
+shape is verified via a recording proxy (DeepSeek's 200/400 is ignored;
+only the relay's outbound body is asserted).
+
+## Kimi / Moonshot (live tests)
+
+| Model | Wire shape | Notes |
+|---|---|---|
+| `kimi-k2.6` | Chat Completions | Accepts standard OpenAI multimodal content (verified 2026-05-11) |
+| `moonshot-v1-32k-vision-preview` | Chat Completions | Dedicated vision preview, backup pin |
+
+Used as our happy-path image-input verification since DeepSeek doesn't yet
+support vision on its Chat Completions endpoint. Gated by `MOONSHOT_API_KEY`:
+
+```
+MOONSHOT_API_KEY=sk-... cargo test --test compat_kimi_live -- --ignored
+```
+
 Tests are `#[ignore]` so the default `cargo test` stays fully offline.
 
 ## codex-relay

--- a/tests/fixtures/codex_0_128_0/with_image_input.json
+++ b/tests/fixtures/codex_0_128_0/with_image_input.json
@@ -1,0 +1,19 @@
+{
+  "model": "deepseek-v4-pro",
+  "instructions": "Describe images briefly.",
+  "input": [
+    {
+      "type": "message",
+      "role": "user",
+      "content": [
+        { "type": "input_text", "text": "What is in this image?" },
+        {
+          "type": "input_image",
+          "image_url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        }
+      ]
+    }
+  ],
+  "tools": [],
+  "stream": false
+}


### PR DESCRIPTION
## Summary

Resolves the 413 crash from #2 by lifting the body limit and adds proper multimodal forwarding so vision-capable upstreams actually receive the image.

- **Body limit**: disabled axum's default 2 MiB cap on the relay router. Codex CLI's base64-embedded images easily exceed 2 MiB, axum was returning 413 before our handler ran, and Codex CLI treated that as a transport-layer death.
- **Multimodal translation**: `input_image` content parts now translate into Chat Completions `{type:"image_url", image_url:{url}}` parts. Text-only content arrays still collapse to plain strings (keeps the reasoning fingerprint stable). `ChatMessage.content` widened from `Option<String>` to `Option<Value>`; `text_content()` accessor for code that only cares about the text view.
- **Wire-shape contract**: locked in by an offline fixture-based test that runs in default `cargo test`, plus live tests against two providers.

Refs #2 (left open for owner follow-up — do not auto-close).

## Live verification (2026-05-11)

| Upstream | Result |
|---|---|
| **Kimi `kimi-k2.6`** | ✓ Standard OpenAI multimodal shape accepted; relay's translation passes through end-to-end, model describes the image. Happy-path pin. |
| **Kimi `moonshot-v1-32k-vision-preview`** | ✓ Same — backup pin. |
| **DeepSeek `deepseek-v4-pro`** | ✗ Chat Completions endpoint does NOT accept any image content-part variant (tried `image_url`, `input_image`, `image` — all return `400: unknown variant '<X>', expected 'text'`). Pinned as a tripwire — when DeepSeek enables vision, that test will fail and prompt flipping it into a happy-path. |

So the relay does the right thing per OpenAI spec. Kimi proves it lands end-to-end; DeepSeek confirms that pre-vision providers now produce a readable 400 instead of crashing Codex.

## Test plan

- [x] `cargo test` — 64 offline tests pass (22 lib + 33 main + 4 codex-0.128 + 5 deepseek-v4-pro). Includes new offline fixture that pins the multimodal wire shape independent of any live key.
- [x] `DEEPSEEK_API_KEY=... cargo test --test compat_deepseek_live -- --ignored --test-threads=1` — all 10 live tests pass (8 prior + 2 new image tests, both via recording proxy since DeepSeek 400s on images).
- [x] `MOONSHOT_API_KEY=... cargo test --test compat_kimi_live -- --ignored --test-threads=1` — both image-input live tests pass against `kimi-k2.6` and `moonshot-v1-32k-vision-preview`.