### PR TITLE
[codex] Fix streaming usage and MCP namespaces

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -12,7 +12,8 @@ use tracing::{error, warn};
 
 use crate::{
     session::SessionStore,
-    types::{ChatMessage, ChatRequest, ChatStreamChunk},
+    translate::split_mcp_function_name,
+    types::{ChatMessage, ChatRequest, ChatStreamChunk, ChatUsage},
 };
 
 pub struct StreamArgs {
@@ -97,6 +98,7 @@ pub fn translate_stream(
         let mut tool_calls: BTreeMap<usize, ToolCallAccum> = BTreeMap::new();
         let mut emitted_message_item = false;
         let mut stream_done = false;
+        let mut stream_usage: Option<ChatUsage> = None;
         let mut source = upstream.bytes_stream().eventsource();
 
         while let Some(ev) = source.next().await {
@@ -114,7 +116,11 @@ pub fn translate_stream(
                     match serde_json::from_str::<ChatStreamChunk>(&ev.data) {
                         Err(e) => warn!("chunk parse error: {e} — data: {}", ev.data),
                         Ok(chunk) => {
-                            for choice in &chunk.choices {
+                            let ChatStreamChunk { choices, usage } = chunk;
+                            if usage.is_some() {
+                                stream_usage = usage;
+                            }
+                            for choice in &choices {
                                 // Reasoning/thinking content (kimi-k2.6 etc.)
                                 if let Some(rc) = choice.delta.reasoning_content.as_deref() {
                                     if !rc.is_empty() {
@@ -207,20 +213,34 @@ pub fn translate_stream(
         for (rel_idx, (_, tc)) in tool_calls.iter().enumerate() {
             let fc_item_id = format!("fc_{}", uuid::Uuid::new_v4().simple());
             let output_index = base_index + rel_idx;
+            let (namespace, name) = split_mcp_function_name(&tc.name);
+            let mut added_item = json!({
+                "type": "function_call",
+                "id": &fc_item_id,
+                "call_id": &tc.id,
+                "name": &name,
+                "arguments": "",
+                "status": "in_progress"
+            });
+            let mut done_item = json!({
+                "type": "function_call",
+                "id": &fc_item_id,
+                "call_id": &tc.id,
+                "name": &name,
+                "arguments": &tc.arguments,
+                "status": "completed"
+            });
+            if let Some(namespace) = namespace {
+                added_item["namespace"] = Value::String(namespace.clone());
+                done_item["namespace"] = Value::String(namespace);
+            }
 
             yield Ok(Event::default()
                 .event("response.output_item.added")
                 .data(json!({
                     "type": "response.output_item.added",
                     "output_index": output_index,
-                    "item": {
-                        "type": "function_call",
-                        "id": &fc_item_id,
-                        "call_id": &tc.id,
-                        "name": &tc.name,
-                        "arguments": "",
-                        "status": "in_progress"
-                    }
+                    "item": added_item
                 }).to_string()));
 
             if !tc.arguments.is_empty() {
@@ -239,24 +259,10 @@ pub fn translate_stream(
                 .data(json!({
                     "type": "response.output_item.done",
                     "output_index": output_index,
-                    "item": {
-                        "type": "function_call",
-                        "id": &fc_item_id,
-                        "call_id": &tc.id,
-                        "name": &tc.name,
-                        "arguments": &tc.arguments,
-                        "status": "completed"
-                    }
+                    "item": done_item
                 }).to_string()));
 
-            fc_items.push(json!({
-                "type": "function_call",
-                "id": fc_item_id,
-                "call_id": &tc.id,
-                "name": &tc.name,
-                "arguments": &tc.arguments,
-                "status": "completed"
-            }));
+            fc_items.push(done_item);
         }
 
         if stream_done {
@@ -311,6 +317,7 @@ pub fn translate_stream(
                 }));
             }
             output_items.extend(fc_items);
+            let usage = stream_usage.unwrap_or_default();
 
             yield Ok(Event::default()
                 .event("response.completed")
@@ -320,7 +327,12 @@ pub fn translate_stream(
                         "id": &response_id,
                         "status": "completed",
                         "model": &model,
-                        "output": output_items
+                        "output": output_items,
+                        "usage": {
+                            "input_tokens": usage.prompt_tokens,
+                            "output_tokens": usage.completion_tokens,
+                            "total_tokens": usage.total_tokens
+                        }
                     }
                 }).to_string()));
         } else {

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -4,7 +4,11 @@ use std::collections::HashSet;
 use crate::{session::SessionStore, types::*};
 
 /// Convert a Responses API request + prior history into a Chat Completions request.
-pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessions: &SessionStore) -> ChatRequest {
+pub fn to_chat_request(
+    req: &ResponsesRequest,
+    history: Vec<ChatMessage>,
+    sessions: &SessionStore,
+) -> ChatRequest {
     let mut messages = history;
 
     // Prefer `instructions` (Codex CLI) over `system` (other clients).
@@ -41,12 +45,14 @@ pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessio
             // Collect call_ids already present in history (from previous_response_id).
             // This prevents creating duplicate assistant-with-tool_calls messages
             // when the input items replay function_call entries from prior output.
-            let existing_call_ids: HashSet<String> = messages.iter()
+            let existing_call_ids: HashSet<String> = messages
+                .iter()
                 .flat_map(|msg| {
                     let mut ids: Vec<String> = Vec::new();
                     if let Some(tcs) = &msg.tool_calls {
-                        ids.extend(tcs.iter()
-                            .filter_map(|tc| tc.get("id").and_then(|v| v.as_str()).map(String::from)));
+                        ids.extend(tcs.iter().filter_map(|tc| {
+                            tc.get("id").and_then(|v| v.as_str()).map(String::from)
+                        }));
                     }
                     ids.extend(msg.tool_call_id.iter().cloned());
                     ids
@@ -55,7 +61,8 @@ pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessio
 
             // For function_call_output dedup, only skip if a tool response
             // already exists for the call_id (not just from assistant tool_calls).
-            let existing_tool_responses: HashSet<String> = messages.iter()
+            let existing_tool_responses: HashSet<String> = messages
+                .iter()
                 .filter_map(|msg| msg.tool_call_id.clone())
                 .collect();
 
@@ -83,12 +90,16 @@ pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessio
 
                     while i < items.len() {
                         let cur = &items[i];
-                        if cur.get("type").and_then(|v| v.as_str()).unwrap_or("") != "function_call" {
+                        if cur.get("type").and_then(|v| v.as_str()).unwrap_or("") != "function_call"
+                        {
                             break;
                         }
                         let call_id = cur.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
-                        let name    = cur.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                        let args    = cur.get("arguments").and_then(|v| v.as_str()).unwrap_or("{}");
+                        let name = response_function_name_for_chat(cur);
+                        let args = cur
+                            .get("arguments")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("{}");
                         if reasoning_content.is_none() {
                             reasoning_content = sessions.get_reasoning(call_id);
                         }
@@ -116,14 +127,15 @@ pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessio
                 } else {
                     match item_type {
                         "function_call_output" => {
-                            let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
+                            let call_id =
+                                item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
                             // Skip function_call_output items if a tool response
                             // for this call_id already exists in history.
                             if existing_tool_responses.contains(call_id) {
                                 i += 1;
                                 continue;
                             }
-                            let output  = item.get("output").and_then(|v| v.as_str()).unwrap_or("");
+                            let output = item.get("output").and_then(|v| v.as_str()).unwrap_or("");
                             messages.push(ChatMessage {
                                 role: "tool".into(),
                                 content: Some(Value::String(output.to_string())),
@@ -159,7 +171,8 @@ pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessio
                             // from the turn-level index (needed for thinking models like
                             // DeepSeek that require reasoning_content to be passed back).
                             if msg.role == "assistant" {
-                                msg.reasoning_content = sessions.get_turn_reasoning(&messages, &msg);
+                                msg.reasoning_content =
+                                    sessions.get_turn_reasoning(&messages, &msg);
                             }
                             // System/developer messages from input items must go to the
                             // front of the array. Codex sometimes interleaves them between
@@ -189,6 +202,9 @@ pub fn to_chat_request(req: &ResponsesRequest, history: Vec<ChatMessage>, sessio
         tools: convert_tools(&req.tools),
         temperature: req.temperature,
         max_tokens: req.max_output_tokens,
+        stream_options: req.stream.then_some(ChatStreamOptions {
+            include_usage: true,
+        }),
         stream: req.stream,
     }
 }
@@ -222,10 +238,15 @@ fn convert_tools(tools: &[Value]) -> Vec<Value> {
         match tool.get("type").and_then(Value::as_str) {
             Some("function") => out.push(convert_tool(tool)),
             Some("namespace") => {
+                let namespace = tool.get("name").and_then(Value::as_str).unwrap_or("");
                 if let Some(subs) = tool.get("tools").and_then(Value::as_array) {
                     for sub in subs {
                         if sub.get("type").and_then(Value::as_str) == Some("function") {
-                            out.push(convert_tool(sub));
+                            let name = sub
+                                .get("name")
+                                .and_then(Value::as_str)
+                                .map(|name| format!("{namespace}{name}"));
+                            out.push(convert_tool_with_name(sub, name.as_deref()));
                         }
                     }
                 }
@@ -244,23 +265,49 @@ fn convert_tools(tools: &[Value]) -> Vec<Value> {
 /// Chat Completions (nested):
 ///   {"type":"function","function":{"name":"foo","description":"...","parameters":{...}}}
 fn convert_tool(tool: &Value) -> Value {
+    convert_tool_with_name(tool, None)
+}
+
+fn convert_tool_with_name(tool: &Value, override_name: Option<&str>) -> Value {
     let Some(obj) = tool.as_object() else {
         return tool.clone();
     };
     // Already in Chat Completions format if it has a "function" sub-object.
     if obj.contains_key("function") {
-        return tool.clone();
+        let mut tool = tool.clone();
+        if let Some(name) = override_name {
+            if let Some(func) = tool.get_mut("function").and_then(Value::as_object_mut) {
+                func.insert("name".into(), Value::String(name.to_string()));
+            }
+        }
+        return tool;
     }
     // Convert from Responses API flat format.
     if obj.get("type").and_then(Value::as_str) == Some("function") {
         let mut func = serde_json::Map::new();
-        if let Some(v) = obj.get("name") { func.insert("name".into(), v.clone()); }
-        if let Some(v) = obj.get("description") { func.insert("description".into(), v.clone()); }
-        if let Some(v) = obj.get("parameters") { func.insert("parameters".into(), v.clone()); }
-        if let Some(v) = obj.get("strict") { func.insert("strict".into(), v.clone()); }
+        if let Some(name) = override_name {
+            func.insert("name".into(), Value::String(name.to_string()));
+        } else if let Some(v) = obj.get("name") {
+            func.insert("name".into(), v.clone());
+        }
+        if let Some(v) = obj.get("description") {
+            func.insert("description".into(), v.clone());
+        }
+        if let Some(v) = obj.get("parameters") {
+            func.insert("parameters".into(), v.clone());
+        }
+        if let Some(v) = obj.get("strict") {
+            func.insert("strict".into(), v.clone());
+        }
         return json!({"type": "function", "function": func});
     }
     tool.clone()
+}
+
+fn response_function_name_for_chat(item: &Value) -> String {
+    let name = item.get("name").and_then(Value::as_str).unwrap_or("");
+    let namespace = item.get("namespace").and_then(Value::as_str).unwrap_or("");
+    format!("{namespace}{name}")
 }
 
 /// Convert a Chat Completions response into a Responses API response.
@@ -269,36 +316,68 @@ pub fn from_chat_response(
     model: &str,
     chat: ChatResponse,
 ) -> (ResponsesResponse, Vec<ChatMessage>) {
-    let choice = chat.choices.into_iter().next().unwrap_or_else(|| ChatChoice {
-        message: ChatMessage {
-            role: "assistant".into(),
-            content: Some(Value::String(String::new())),
-            reasoning_content: None,
-            tool_calls: None,
-            tool_call_id: None,
-            name: None,
-        },
-    });
+    let choice = chat
+        .choices
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| ChatChoice {
+            message: ChatMessage {
+                role: "assistant".into(),
+                content: Some(Value::String(String::new())),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
+            },
+        });
+
+    let usage = chat.usage.unwrap_or_default();
+    let mut output = Vec::new();
 
     let text = choice.message.text_content().to_string();
-    let usage = chat.usage.unwrap_or(ChatUsage {
-        prompt_tokens: 0,
-        completion_tokens: 0,
-        total_tokens: 0,
-    });
+    if !text.is_empty() || choice.message.tool_calls.is_none() {
+        output.push(json!({
+            "type": "message",
+            "role": "assistant",
+            "content": [{
+                "type": "output_text",
+                "text": text,
+            }],
+        }));
+    }
+
+    if let Some(tool_calls) = &choice.message.tool_calls {
+        for tool_call in tool_calls {
+            let function = tool_call.get("function").unwrap_or(&Value::Null);
+            let raw_name = function.get("name").and_then(Value::as_str).unwrap_or("");
+            let (namespace, name) = split_mcp_function_name(raw_name);
+            let arguments = function
+                .get("arguments")
+                .and_then(Value::as_str)
+                .unwrap_or("{}");
+            let mut item = json!({
+                "type": "function_call",
+                "id": format!("fc_{}", uuid::Uuid::new_v4().simple()),
+                "call_id": tool_call
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or(""),
+                "name": name,
+                "arguments": arguments,
+                "status": "completed"
+            });
+            if let Some(namespace) = namespace {
+                item["namespace"] = Value::String(namespace);
+            }
+            output.push(item);
+        }
+    }
 
     let response = ResponsesResponse {
         id,
         object: "response",
         model: model.to_string(),
-        output: vec![ResponsesOutputItem {
-            kind: "message".into(),
-            role: "assistant".into(),
-            content: vec![ContentPart {
-                kind: "output_text".into(),
-                text: Some(text),
-            }],
-        }],
+        output,
         usage: ResponsesUsage {
             input_tokens: usage.prompt_tokens,
             output_tokens: usage.completion_tokens,
@@ -307,6 +386,23 @@ pub fn from_chat_response(
     };
 
     (response, vec![choice.message])
+}
+
+pub(crate) fn split_mcp_function_name(name: &str) -> (Option<String>, String) {
+    let Some(rest) = name.strip_prefix("mcp__") else {
+        return (None, name.to_string());
+    };
+    let Some(server_end) = rest.find("__") else {
+        return (None, name.to_string());
+    };
+    let split_at = "mcp__".len() + server_end + "__".len();
+    if split_at >= name.len() {
+        return (None, name.to_string());
+    }
+    (
+        Some(name[..split_at].to_string()),
+        name[split_at..].to_string(),
+    )
 }
 
 /// Translate a Responses-API `content` value to its Chat Completions equivalent.
@@ -360,10 +456,7 @@ fn map_content_part(part: &Value) -> Value {
         "input_image" => {
             // Responses API: image_url is a plain string (often a data: URL).
             // Chat Completions wants it wrapped in an object.
-            let url = part
-                .get("image_url")
-                .and_then(|u| u.as_str())
-                .unwrap_or("");
+            let url = part.get("image_url").and_then(|u| u.as_str()).unwrap_or("");
             json!({"type": "image_url", "image_url": {"url": url}})
         }
         "image_url" => {
@@ -384,6 +477,9 @@ fn map_content_part(part: &Value) -> Value {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn base_req(input: ResponsesInput) -> ResponsesRequest {
         ResponsesRequest {
@@ -444,6 +540,55 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0]["id"], "c1");
         assert_eq!(calls[1]["id"], "c2");
+    }
+
+    #[test]
+    fn test_namespaced_function_call_replays_to_flattened_chat_name() {
+        let sessions = SessionStore::new();
+        let req = base_req(ResponsesInput::Messages(vec![json!({
+            "type": "function_call",
+            "call_id": "call_status",
+            "namespace": "mcp__burp_ai_agent__",
+            "name": "status",
+            "arguments": "{}"
+        })]));
+        let chat = to_chat_request(&req, vec![], &sessions);
+        let calls = chat.messages[0].tool_calls.as_ref().unwrap();
+        assert_eq!(
+            calls[0]["function"]["name"].as_str(),
+            Some("mcp__burp_ai_agent__status")
+        );
+    }
+
+    #[test]
+    fn test_from_chat_response_splits_mcp_function_call_namespace() {
+        let chat = ChatResponse {
+            choices: vec![ChatChoice {
+                message: ChatMessage {
+                    role: "assistant".into(),
+                    content: None,
+                    reasoning_content: None,
+                    tool_calls: Some(vec![json!({
+                        "id": "call_status",
+                        "type": "function",
+                        "function": {
+                            "name": "mcp__burp_ai_agent__status",
+                            "arguments": "{}"
+                        }
+                    })]),
+                    tool_call_id: None,
+                    name: None,
+                },
+            }],
+            usage: None,
+        };
+
+        let (resp, _) = from_chat_response("resp_1".into(), "test-model", chat);
+        assert_eq!(resp.output.len(), 1);
+        assert_eq!(resp.output[0]["type"], "function_call");
+        assert_eq!(resp.output[0]["namespace"], "mcp__burp_ai_agent__");
+        assert_eq!(resp.output[0]["name"], "status");
+        assert_eq!(resp.output[0]["call_id"], "call_status");
     }
 
     #[test]
@@ -607,7 +752,11 @@ mod tests {
 
         // Should have: user, assistant{tool_calls:[call_1]}, tool(call_1), user(next)
         // NOT: user, assistant{tool_calls:[call_1]}, assistant{tool_calls:[call_1]}, tool(call_1), user
-        assert_eq!(chat.messages.len(), 4, "should not duplicate assistant tool_calls message");
+        assert_eq!(
+            chat.messages.len(),
+            4,
+            "should not duplicate assistant tool_calls message"
+        );
         assert_eq!(chat.messages[0].role, "user");
         assert_eq!(chat.messages[1].role, "assistant");
         assert!(chat.messages[1].tool_calls.is_some());
@@ -687,8 +836,11 @@ mod tests {
         ]));
         let chat = to_chat_request(&req, vec![], &sessions);
         let roles: Vec<&str> = chat.messages.iter().map(|m| m.role.as_str()).collect();
-        assert_eq!(roles, ["system", "assistant", "tool", "user"],
-            "system must be at front, assistant→tool pairing must be contiguous");
+        assert_eq!(
+            roles,
+            ["system", "assistant", "tool", "user"],
+            "system must be at front, assistant→tool pairing must be contiguous"
+        );
     }
 
     /// When a system/developer message appears at the very start of input
@@ -725,7 +877,11 @@ mod tests {
 
     #[test]
     fn test_map_model_name_with_env() {
-        std::env::set_var("CODEX_RELAY_MODEL_MAP", "gpt-5.4:deepseek-v4-pro,gpt-5.5:deepseek-v4-pro");
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(
+            "CODEX_RELAY_MODEL_MAP",
+            "gpt-5.4:deepseek-v4-pro,gpt-5.5:deepseek-v4-pro",
+        );
         assert_eq!(map_model_name("gpt-5.4"), "deepseek-v4-pro");
         assert_eq!(map_model_name("gpt-5.5"), "deepseek-v4-pro");
         std::env::remove_var("CODEX_RELAY_MODEL_MAP");
@@ -733,6 +889,7 @@ mod tests {
 
     #[test]
     fn test_map_model_name_no_match_passthrough() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("CODEX_RELAY_MODEL_MAP", "gpt-5.4:deepseek-v4-pro");
         assert_eq!(map_model_name("unknown-model"), "unknown-model");
         std::env::remove_var("CODEX_RELAY_MODEL_MAP");
@@ -740,13 +897,18 @@ mod tests {
 
     #[test]
     fn test_map_model_name_no_env_var() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::remove_var("CODEX_RELAY_MODEL_MAP");
         assert_eq!(map_model_name("gpt-5.4"), "gpt-5.4");
     }
 
     #[test]
     fn test_map_model_name_trims_whitespace() {
-        std::env::set_var("CODEX_RELAY_MODEL_MAP", " gpt-5.4 : deepseek-v4-pro , gpt-5.5 : deepseek-v4-flash ");
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var(
+            "CODEX_RELAY_MODEL_MAP",
+            " gpt-5.4 : deepseek-v4-pro , gpt-5.5 : deepseek-v4-flash ",
+        );
         assert_eq!(map_model_name("gpt-5.4"), "deepseek-v4-pro");
         assert_eq!(map_model_name("gpt-5.5"), "deepseek-v4-flash");
         std::env::remove_var("CODEX_RELAY_MODEL_MAP");

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,16 +46,8 @@ pub struct ResponsesResponse {
     pub id: String,
     pub object: &'static str,
     pub model: String,
-    pub output: Vec<ResponsesOutputItem>,
+    pub output: Vec<Value>,
     pub usage: ResponsesUsage,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ResponsesOutputItem {
-    #[serde(rename = "type")]
-    pub kind: String,
-    pub role: String,
-    pub content: Vec<ContentPart>,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -77,7 +69,14 @@ pub struct ChatRequest {
     pub temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<ChatStreamOptions>,
     pub stream: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChatStreamOptions {
+    pub include_usage: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -105,10 +104,7 @@ impl ChatMessage {
     /// non-string, or multimodal payloads — callers that care about the
     /// multimodal parts should look at `content` directly.
     pub fn text_content(&self) -> &str {
-        self.content
-            .as_ref()
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
+        self.content.as_ref().and_then(|v| v.as_str()).unwrap_or("")
     }
 }
 
@@ -124,7 +120,7 @@ pub struct ChatChoice {
     pub message: ChatMessage,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 pub struct ChatUsage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
@@ -137,7 +133,6 @@ pub struct ChatUsage {
 pub struct ChatStreamChunk {
     pub choices: Vec<ChatStreamChoice>,
     #[serde(default)]
-    #[allow(dead_code)]
     pub usage: Option<ChatUsage>,
 }
 

--- a/tests/compat_codex_0_128.rs
+++ b/tests/compat_codex_0_128.rs
@@ -30,8 +30,7 @@ fn fixture(name: &str) -> ResponsesRequest {
     p.push("tests/fixtures/codex_0_128_0");
     p.push(name);
     let bytes = std::fs::read(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
-    serde_json::from_slice(&bytes)
-        .unwrap_or_else(|e| panic!("parse {}: {e}", p.display()))
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", p.display()))
 }
 
 #[test]
@@ -56,7 +55,11 @@ fn namespace_tools_are_flattened() {
         .collect();
     assert_eq!(
         names,
-        vec!["exec_command", "_add_comment_to_issue", "_close_issue"]
+        vec![
+            "exec_command",
+            "mcp__codex_apps__github_add_comment_to_issue",
+            "mcp__codex_apps__github_close_issue"
+        ]
     );
 
     // All emitted tools must be in nested Chat Completions shape.
@@ -78,11 +81,7 @@ fn reasoning_input_items_are_dropped() {
     let roles: Vec<&str> = chat.messages.iter().map(|m| m.role.as_str()).collect();
     assert_eq!(roles, ["system", "user", "user"]);
 
-    let texts: Vec<&str> = chat
-        .messages
-        .iter()
-        .map(|m| m.text_content())
-        .collect();
+    let texts: Vec<&str> = chat.messages.iter().map(|m| m.text_content()).collect();
     assert_eq!(texts, ["system", "first turn", "second turn"]);
 }
 

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -1,0 +1,218 @@
+//! Focused repro tests for recent GitHub issues.
+//!
+//! These tests use only local translation code or a local mock upstream; they
+//! do not require a real LLM, Codex Desktop, or an MCP server.
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{header, StatusCode},
+    response::Response,
+    routing::{get, post},
+    Router,
+};
+use codex_relay::session::SessionStore;
+use codex_relay::translate::to_chat_request;
+use codex_relay::types::ResponsesRequest;
+use eventsource_stream::Eventsource;
+use futures_util::StreamExt;
+use serde_json::{json, Value};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const RELAY_BIN: &str = env!("CARGO_BIN_EXE_codex-relay");
+
+fn fixture(name: &str) -> ResponsesRequest {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests/fixtures/codex_0_128_0");
+    p.push(name);
+    let bytes = std::fs::read(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", p.display()))
+}
+
+fn pick_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let p = l.local_addr().unwrap().port();
+    drop(l);
+    p
+}
+
+#[test]
+fn issue_6_namespace_tools_keep_namespace_when_flattened() {
+    let req = fixture("with_namespace_tool.json");
+    let chat = to_chat_request(&req, Vec::new(), &SessionStore::new());
+
+    let names: Vec<String> = chat
+        .tools
+        .iter()
+        .map(|t| {
+            t.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string()
+        })
+        .collect();
+
+    assert!(
+        names
+            .iter()
+            .any(|n| n == "mcp__codex_apps__github_add_comment_to_issue"),
+        "namespace child tool should be flattened with its namespace prefix: {names:?}"
+    );
+}
+
+#[derive(Clone)]
+struct MockState {
+    bodies: Arc<Mutex<Vec<Value>>>,
+}
+
+async fn models_handler() -> axum::Json<Value> {
+    axum::Json(json!({"data": [{"id": "mock-model"}]}))
+}
+
+async fn chat_handler(State(state): State<MockState>, req: axum::extract::Request) -> Response {
+    let bytes = match axum::body::to_bytes(req.into_body(), 1_000_000).await {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::from("bad body"))
+                .unwrap();
+        }
+    };
+    let body: Value = serde_json::from_slice(&bytes).expect("chat request json");
+    state.bodies.lock().unwrap().push(body);
+
+    let sse = concat!(
+        "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"OK\"}}]}\n\n",
+        "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":2,\"total_tokens\":9}}\n\n",
+        "data: [DONE]\n\n",
+    );
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .body(Body::from(sse))
+        .unwrap()
+}
+
+async fn spawn_mock_upstream() -> (u16, Arc<Mutex<Vec<Value>>>) {
+    let port = pick_port();
+    let bodies = Arc::new(Mutex::new(Vec::new()));
+    let state = MockState {
+        bodies: bodies.clone(),
+    };
+    let app = Router::new()
+        .route("/v1/models", get(models_handler))
+        .route("/v1/chat/completions", post(chat_handler))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+        .await
+        .expect("bind mock upstream");
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("mock upstream serve");
+    });
+    (port, bodies)
+}
+
+struct Relay {
+    child: Child,
+    port: u16,
+}
+
+impl Drop for Relay {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Relay {
+    fn spawn(upstream: &str) -> Self {
+        let port = pick_port();
+        let child = Command::new(RELAY_BIN)
+            .env("CODEX_RELAY_PORT", port.to_string())
+            .env("CODEX_RELAY_UPSTREAM", upstream)
+            .env("CODEX_RELAY_API_KEY", "")
+            .env("RUST_LOG", "codex_relay=warn")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn codex-relay");
+
+        let mut handle = Relay { child, port };
+        handle.wait_ready();
+        handle
+    }
+
+    fn wait_ready(&mut self) {
+        let deadline = Instant::now() + Duration::from_secs(8);
+        while Instant::now() < deadline {
+            if std::net::TcpStream::connect(("127.0.0.1", self.port)).is_ok() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(80));
+        }
+        panic!("relay did not become ready on :{}", self.port);
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{}", self.port, path)
+    }
+}
+
+#[tokio::test]
+async fn issue_5_streaming_completed_event_includes_usage() {
+    let (upstream_port, bodies) = spawn_mock_upstream().await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let body = json!({
+        "model": "mock-model",
+        "instructions": "Answer briefly.",
+        "input": "Say OK.",
+        "tools": [],
+        "stream": true
+    });
+
+    let resp = reqwest::Client::new()
+        .post(relay.url("/v1/responses"))
+        .json(&body)
+        .send()
+        .await
+        .expect("POST /v1/responses");
+    assert!(resp.status().is_success(), "status {}", resp.status());
+
+    let mut events = resp.bytes_stream().eventsource();
+    let mut completed: Option<Value> = None;
+    let deadline = Instant::now() + Duration::from_secs(8);
+    while let Some(ev) = tokio::time::timeout(deadline - Instant::now(), events.next())
+        .await
+        .expect("stream timeout")
+    {
+        let ev = ev.expect("sse parse");
+        if ev.event == "response.completed" {
+            completed = Some(serde_json::from_str(&ev.data).expect("completed json"));
+            break;
+        }
+    }
+
+    let completed = completed.expect("response.completed event");
+    assert_eq!(
+        completed["response"]["usage"],
+        json!({"input_tokens": 7, "output_tokens": 2, "total_tokens": 9})
+    );
+
+    let request_bodies = bodies.lock().unwrap();
+    let upstream_body = request_bodies.first().expect("upstream chat request");
+    assert_eq!(
+        upstream_body["stream_options"],
+        json!({"include_usage": true}),
+        "streaming Chat Completions requests must ask upstream to include usage"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes two Codex compatibility regressions reported in #5 and #6:

- include stream_options include_usage for streaming Chat Completions requests and propagate upstream streaming usage into response.completed.response.usage
- flatten Responses API namespace tools into Chat Completions function names with the namespace prefix preserved
- split mcp__server__tool function calls back into Responses API namespace + name fields in both blocking and streaming response translation
- preserve namespace-aware replay when Codex sends previous function_call items back in the next turn
- add local regression tests using translation-only checks and a mock SSE upstream

## Validation

- cargo test
- rustfmt --check --edition 2021 src/types.rs src/translate.rs src/stream.rs tests/regression_issues.rs tests/compat_codex_0_128.rs