### PR TITLE
[codex] Bound retained session state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,6 @@ dependencies = [
  "axum",
  "bytes",
  "clap",
- "dashmap",
  "eventsource-stream",
  "futures-util",
  "pin-project-lite",
@@ -275,26 +274,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
 
 [[package]]
 name = "displaydoc"
@@ -454,12 +433,6 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 uuid = { version = "1", features = ["v4"] }
-dashmap = "6"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ input_modalities = ["text"]
 | `--api-key` | `CODEX_RELAY_API_KEY` | _(empty)_ | API key forwarded to upstream |
 | `--model-map` | `CODEX_RELAY_MODEL_MAP` | _(empty)_ | Comma-separated `source:target` model name translations |
 | `--print-config` | _(none)_ | — | Print a Codex config snippet with `model_properties` and exit |
+| `--session-ttl-hours` | `CODEX_RELAY_SESSION_TTL_HOURS` | `168` | Retain idle `previous_response_id` history and reasoning state for this many hours |
+| `--max-sessions` | `CODEX_RELAY_MAX_SESSIONS` | `256` | Maximum completed response histories retained for continuation |
+| `--max-session-memory-mb` | `CODEX_RELAY_MAX_SESSION_MEMORY_MB` | `512` | Approximate memory budget for retained session/reasoning state |
 
 ## Supported providers
 
@@ -115,6 +118,9 @@ Any OpenAI-compatible endpoint works.
 | `CODEX_RELAY_UPSTREAM` | `https://openrouter.ai/api/v1` | Upstream Chat Completions base URL |
 | `CODEX_RELAY_API_KEY` | _(empty)_ | API key forwarded to upstream |
 | `CODEX_RELAY_MODEL_MAP` | _(empty)_ | Comma-separated `source:target` model name translations (e.g., `gpt-5.4:deepseek-v4-pro`) |
+| `CODEX_RELAY_SESSION_TTL_HOURS` | `168` | Retain idle session/reasoning state for this many hours |
+| `CODEX_RELAY_MAX_SESSIONS` | `256` | Maximum completed response histories retained for `previous_response_id` |
+| `CODEX_RELAY_MAX_SESSION_MEMORY_MB` | `512` | Approximate memory budget for retained session/reasoning state |
 | `RUST_LOG` | `codex_relay=info` | Log verbosity |
 
 ## Python API

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,13 +13,16 @@ use axum::{
 };
 use clap::Parser;
 use reqwest::{Client, Url};
-use session::SessionStore;
+use session::{SessionStore, DEFAULT_MAX_SESSIONS, DEFAULT_MAX_SESSION_BYTES, DEFAULT_SESSION_TTL};
 use std::{sync::Arc, time::Duration};
 use tracing::{debug, error, info, warn};
 use types::*;
 
 #[derive(Parser, Debug)]
-#[command(name = "codex-relay", about = "Responses API ↔ Chat Completions bridge")]
+#[command(
+    name = "codex-relay",
+    about = "Responses API ↔ Chat Completions bridge"
+)]
 struct Args {
     #[arg(long, env = "CODEX_RELAY_PORT", default_value = "4444")]
     port: u16,
@@ -38,6 +41,30 @@ struct Args {
     /// for all models exposed by the upstream provider.
     #[arg(long)]
     print_config: bool,
+
+    /// Maximum completed response histories retained for previous_response_id.
+    #[arg(
+        long,
+        env = "CODEX_RELAY_MAX_SESSIONS",
+        default_value_t = DEFAULT_MAX_SESSIONS
+    )]
+    max_sessions: usize,
+
+    /// Approximate memory budget for retained session/reasoning state, in MiB.
+    #[arg(
+        long,
+        env = "CODEX_RELAY_MAX_SESSION_MEMORY_MB",
+        default_value_t = DEFAULT_MAX_SESSION_BYTES / 1024 / 1024
+    )]
+    max_session_memory_mb: usize,
+
+    /// Retain idle session/reasoning state for this many hours.
+    #[arg(
+        long,
+        env = "CODEX_RELAY_SESSION_TTL_HOURS",
+        default_value_t = DEFAULT_SESSION_TTL.as_secs() / 60 / 60
+    )]
+    session_ttl_hours: u64,
 }
 
 #[derive(Clone)]
@@ -69,27 +96,42 @@ async fn main() -> Result<()> {
         let provider_name = upstream
             .host_str()
             .map(|h| {
-            let h = h.trim_start_matches("api.").trim_start_matches("www.");
-            h.trim_end_matches(".com").trim_end_matches(".cn").trim_end_matches(".ai").trim_end_matches(".org").trim_end_matches(".io")
-        })
+                let h = h.trim_start_matches("api.").trim_start_matches("www.");
+                h.trim_end_matches(".com")
+                    .trim_end_matches(".cn")
+                    .trim_end_matches(".ai")
+                    .trim_end_matches(".org")
+                    .trim_end_matches(".io")
+            })
             .unwrap_or("custom");
         print_codex_config(&client, &upstream, &api_key, provider_name).await;
         return Ok(());
     }
 
+    let max_session_bytes = args
+        .max_session_memory_mb
+        .saturating_mul(1024)
+        .saturating_mul(1024);
+    let session_ttl = Duration::from_secs(args.session_ttl_hours.saturating_mul(60 * 60));
     let state = AppState {
-        sessions: SessionStore::new(),
+        sessions: SessionStore::with_limits_and_ttl(
+            args.max_sessions,
+            max_session_bytes,
+            session_ttl,
+        ),
         client: client.clone(),
         upstream: Arc::new(upstream.clone()),
         api_key: api_key.clone(),
     };
+    info!(
+        "session retention: ttl={}h max_sessions={} max_session_memory={} MiB",
+        args.session_ttl_hours, args.max_sessions, args.max_session_memory_mb
+    );
 
     // Fetch upstream model list asynchronously for user visibility
-    tokio::spawn(log_upstream_models(
-        client,
-        Arc::new(upstream),
-        api_key,
-    ));
+    tokio::spawn(log_upstream_models(client, Arc::new(upstream), api_key));
+
+    tokio::spawn(cleanup_sessions(state.sessions.clone()));
 
     // Disable axum's default 2 MiB body cap: Codex CLI may send base64-encoded
     // image attachments that easily exceed it, and a framework-level 413 looks
@@ -103,7 +145,10 @@ async fn main() -> Result<()> {
         .with_state(state.clone());
 
     let addr = format!("127.0.0.1:{}", args.port);
-    info!("codex-relay listening on {addr} → {}", state.upstream.as_ref());
+    info!(
+        "codex-relay listening on {addr} → {}",
+        state.upstream.as_ref()
+    );
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     axum::serve(listener, app).await?;
@@ -149,10 +194,7 @@ async fn log_upstream_models(client: Client, upstream: Arc<Url>, api_key: Arc<St
                     .unwrap_or_default();
 
                 if !models.is_empty() {
-                    info!(
-                        "upstream models: {}",
-                        models.join(", ")
-                    );
+                    info!("upstream models: {}", models.join(", "));
                     info!(
                         "⚠️  To configure Codex with model metadata, run:  codex-relay --print-config --upstream {} {}",
                         upstream.as_str(),
@@ -161,20 +203,26 @@ async fn log_upstream_models(client: Client, upstream: Arc<Url>, api_key: Arc<St
                 }
             }
         }
-        Ok(Ok(r)) => warn!("upstream models: status {} (check credentials?)", r.status()),
+        Ok(Ok(r)) => warn!(
+            "upstream models: status {} (check credentials?)",
+            r.status()
+        ),
         Ok(Err(e)) => warn!("upstream models: request error: {e}"),
         Err(_elapsed) => warn!("upstream models: request timed out (upstream unreachable?)"),
     }
 }
 
+async fn cleanup_sessions(sessions: SessionStore) {
+    let mut interval = tokio::time::interval(Duration::from_secs(60 * 60));
+    loop {
+        interval.tick().await;
+        sessions.cleanup();
+    }
+}
+
 /// Print a Codex config.toml snippet that includes model_properties for all
 /// upstream models, so users can avoid "model metadata not found" warnings.
-async fn print_codex_config(
-    client: &Client,
-    upstream: &Url,
-    api_key: &str,
-    provider_name: &str,
-) {
+async fn print_codex_config(client: &Client, upstream: &Url, api_key: &str, provider_name: &str) {
     let url = format!("{}models", join_base(upstream));
     let mut builder = client.get(&url);
     if !api_key.is_empty() {
@@ -182,25 +230,23 @@ async fn print_codex_config(
     }
 
     let models: Vec<String> = match builder.send().await {
-        Ok(r) if r.status().is_success() => {
-            match r.json::<serde_json::Value>().await {
-                Ok(body) => body
-                    .get("data")
-                    .or_else(|| body.get("models"))
-                    .and_then(|v| v.as_array())
-                    .map(|a| {
-                        a.iter()
-                            .filter_map(|m| m.get("id").and_then(|id| id.as_str()).map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                Err(e) => {
-                    eprintln!("// Failed to parse upstream models: {e}");
-                    eprintln!("// Falling back to a generic snippet. Replace <YOUR_MODEL> below.");
-                    vec!["<YOUR_MODEL>".into()]
-                }
+        Ok(r) if r.status().is_success() => match r.json::<serde_json::Value>().await {
+            Ok(body) => body
+                .get("data")
+                .or_else(|| body.get("models"))
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|m| m.get("id").and_then(|id| id.as_str()).map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            Err(e) => {
+                eprintln!("// Failed to parse upstream models: {e}");
+                eprintln!("// Falling back to a generic snippet. Replace <YOUR_MODEL> below.");
+                vec!["<YOUR_MODEL>".into()]
             }
-        }
+        },
         status => {
             eprintln!("// Failed to fetch upstream models (status: {status:?})");
             eprintln!("// Falling back to a generic snippet. Replace <YOUR_MODEL> below.");
@@ -224,14 +270,14 @@ async fn print_codex_config(
     println!();
     println!("[model_providers.{provider_name}]");
     println!("name = \"{}\"", provider_name);
-    println!(
-        "base_url = \"{}\"",
-        upstream.as_str().trim_end_matches('/')
-    );
+    println!("base_url = \"{}\"", upstream.as_str().trim_end_matches('/'));
     println!("wire_api = \"responses\"");
     println!(
         "env_key = \"{}_API_KEY\"",
-        provider_name.to_uppercase().replace('-', "_").replace('.', "_")
+        provider_name
+            .to_uppercase()
+            .replace('-', "_")
+            .replace('.', "_")
     );
     println!();
 
@@ -364,10 +410,7 @@ async fn handle_fallback(req: Request) -> Response {
     (StatusCode::NOT_FOUND, "not found").into_response()
 }
 
-async fn handle_responses(
-    State(state): State<AppState>,
-    body: axum::body::Bytes,
-) -> Response {
+async fn handle_responses(State(state): State<AppState>, body: axum::body::Bytes) -> Response {
     let req: ResponsesRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,
         Err(e) => {
@@ -560,5 +603,4 @@ mod tests {
         assert!(!props.supports_reasoning_summaries);
         assert!(props.supports_parallel_tool_calls);
     }
-
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,9 +1,15 @@
-use dashmap::DashMap;
+use std::collections::{HashMap, VecDeque};
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::types::ChatMessage;
+
+pub const DEFAULT_MAX_SESSIONS: usize = 256;
+pub const DEFAULT_MAX_SESSION_BYTES: usize = 512 * 1024 * 1024;
+pub const DEFAULT_SESSION_TTL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
 /// Maps response_id → accumulated message history for that session.
 /// Codex uses `previous_response_id` to continue a conversation; we maintain
@@ -19,18 +25,68 @@ use crate::types::ChatMessage;
 /// without using `previous_response_id`.
 #[derive(Clone)]
 pub struct SessionStore {
-    inner: Arc<DashMap<String, Vec<ChatMessage>>>,
-    reasoning: Arc<DashMap<String, String>>,
-    /// fingerprint(prior_messages, assistant_content) → reasoning_content
-    turn_reasoning: Arc<DashMap<u64, String>>,
+    state: Arc<Mutex<SessionState>>,
+}
+
+struct SessionState {
+    sessions: HashMap<String, SessionEntry>,
+    session_order: VecDeque<String>,
+    reasoning: HashMap<String, StoredString>,
+    reasoning_order: VecDeque<String>,
+    /// fingerprint(prior_messages, assistant_content) -> reasoning_content
+    turn_reasoning: HashMap<u64, StoredString>,
+    turn_reasoning_order: VecDeque<u64>,
+    stored_bytes: usize,
+    max_sessions: usize,
+    max_stored_bytes: usize,
+    ttl: Duration,
+}
+
+struct SessionEntry {
+    messages: Vec<ChatMessage>,
+    bytes: usize,
+    last_used_at: Instant,
+}
+
+struct StoredString {
+    value: String,
+    bytes: usize,
+    last_used_at: Instant,
 }
 
 impl SessionStore {
+    #[allow(dead_code)]
     pub fn new() -> Self {
+        Self::with_limits_and_ttl(
+            DEFAULT_MAX_SESSIONS,
+            DEFAULT_MAX_SESSION_BYTES,
+            DEFAULT_SESSION_TTL,
+        )
+    }
+
+    #[allow(dead_code)]
+    pub fn with_limits(max_sessions: usize, max_stored_bytes: usize) -> Self {
+        Self::with_limits_and_ttl(max_sessions, max_stored_bytes, DEFAULT_SESSION_TTL)
+    }
+
+    pub fn with_limits_and_ttl(
+        max_sessions: usize,
+        max_stored_bytes: usize,
+        ttl: Duration,
+    ) -> Self {
         Self {
-            inner: Arc::new(DashMap::new()),
-            reasoning: Arc::new(DashMap::new()),
-            turn_reasoning: Arc::new(DashMap::new()),
+            state: Arc::new(Mutex::new(SessionState {
+                sessions: HashMap::new(),
+                session_order: VecDeque::new(),
+                reasoning: HashMap::new(),
+                reasoning_order: VecDeque::new(),
+                turn_reasoning: HashMap::new(),
+                turn_reasoning_order: VecDeque::new(),
+                stored_bytes: 0,
+                max_sessions: max_sessions.max(1),
+                max_stored_bytes: max_stored_bytes.max(1),
+                ttl: ttl.max(Duration::from_secs(1)),
+            })),
         }
     }
 
@@ -38,47 +94,73 @@ impl SessionStore {
     /// injected back when the same call_id appears in a subsequent request.
     pub fn store_reasoning(&self, call_id: String, reasoning: String) {
         if !reasoning.is_empty() {
-            self.reasoning.insert(call_id, reasoning);
+            let mut state = self.state.lock().expect("session store mutex poisoned");
+            state.insert_reasoning(call_id, reasoning);
+            state.enforce_limits();
         }
     }
 
     /// Look up stored reasoning_content for a call_id.
     pub fn get_reasoning(&self, call_id: &str) -> Option<String> {
-        self.reasoning.get(call_id).map(|v| v.clone())
+        let mut state = self.state.lock().expect("session store mutex poisoned");
+        state.enforce_limits();
+        let value = state.reasoning.get(call_id).map(|v| v.value.clone());
+        if value.is_some() {
+            state.touch_reasoning(call_id);
+        }
+        value
     }
 
     /// Store reasoning_content for an assistant turn, keyed by a fingerprint
     /// of the assistant message content and tool calls.
-    pub fn store_turn_reasoning(&self, _prior: &[ChatMessage], assistant: &ChatMessage, reasoning: String) {
+    pub fn store_turn_reasoning(
+        &self,
+        _prior: &[ChatMessage],
+        assistant: &ChatMessage,
+        reasoning: String,
+    ) {
         if !reasoning.is_empty() {
+            let mut state = self.state.lock().expect("session store mutex poisoned");
+
             // Store under content-only key so lookups work even when Codex
             // replays the assistant text and function_calls as separate items.
             let content = assistant.text_content();
             if !content.is_empty() {
                 let key = Self::content_key(content);
-                self.turn_reasoning.insert(key, reasoning.clone());
+                state.insert_turn_reasoning(key, reasoning.clone());
             }
             // Also store under each tool call_id (existing mechanism).
             if let Some(tcs) = &assistant.tool_calls {
                 for tc in tcs {
                     if let Some(id) = tc.get("id").and_then(|v| v.as_str()) {
                         if !id.is_empty() {
-                            self.store_reasoning(id.to_string(), reasoning.clone());
+                            state.insert_reasoning(id.to_string(), reasoning.clone());
                         }
                     }
                 }
             }
+            state.enforce_limits();
         }
     }
 
     /// Look up reasoning_content for an assistant turn by its text content.
-    pub fn get_turn_reasoning(&self, _prior: &[ChatMessage], assistant: &ChatMessage) -> Option<String> {
+    pub fn get_turn_reasoning(
+        &self,
+        _prior: &[ChatMessage],
+        assistant: &ChatMessage,
+    ) -> Option<String> {
         let content = assistant.text_content();
         if content.is_empty() {
             return None;
         }
         let key = Self::content_key(content);
-        self.turn_reasoning.get(&key).map(|v| v.clone())
+        let mut state = self.state.lock().expect("session store mutex poisoned");
+        state.enforce_limits();
+        let value = state.turn_reasoning.get(&key).map(|v| v.value.clone());
+        if value.is_some() {
+            state.touch_turn_reasoning(key);
+        }
+        value
     }
 
     /// Hash assistant message content for turn-level reasoning lookup.
@@ -90,10 +172,17 @@ impl SessionStore {
 
     /// Retrieve history for a prior response_id, or empty vec if not found.
     pub fn get_history(&self, response_id: &str) -> Vec<ChatMessage> {
-        self.inner
+        let mut state = self.state.lock().expect("session store mutex poisoned");
+        state.enforce_limits();
+        let messages = state
+            .sessions
             .get(response_id)
-            .map(|v| v.clone())
-            .unwrap_or_default()
+            .map(|entry| entry.messages.clone())
+            .unwrap_or_default();
+        if !messages.is_empty() {
+            state.touch_session(response_id);
+        }
+        messages
     }
 
     /// Allocate a fresh response_id without storing anything yet.
@@ -104,14 +193,248 @@ impl SessionStore {
 
     /// Store under a pre-allocated response_id (streaming path).
     pub fn save_with_id(&self, id: String, messages: Vec<ChatMessage>) {
-        self.inner.insert(id, messages);
+        let mut state = self.state.lock().expect("session store mutex poisoned");
+        state.insert_session(id, messages);
+        state.enforce_limits();
     }
 
     /// Allocate an id and store atomically (non-streaming path).
     pub fn save(&self, messages: Vec<ChatMessage>) -> String {
         let id = self.new_id();
-        self.inner.insert(id.clone(), messages);
+        self.save_with_id(id.clone(), messages);
         id
+    }
+
+    /// Drop expired or over-budget retained state.
+    pub fn cleanup(&self) {
+        let mut state = self.state.lock().expect("session store mutex poisoned");
+        state.enforce_limits();
+    }
+}
+
+impl SessionState {
+    fn insert_session(&mut self, id: String, messages: Vec<ChatMessage>) {
+        let bytes = messages_bytes(&messages);
+        if bytes > self.max_stored_bytes {
+            self.remove_session(&id);
+            warn!(
+                "session {id} is {} bytes, above {} byte retention limit; not caching history",
+                bytes, self.max_stored_bytes
+            );
+            return;
+        }
+
+        self.remove_session(&id);
+        let now = Instant::now();
+        self.stored_bytes = self.stored_bytes.saturating_add(bytes);
+        self.sessions.insert(
+            id.clone(),
+            SessionEntry {
+                messages,
+                bytes,
+                last_used_at: now,
+            },
+        );
+        self.session_order.push_back(id);
+    }
+
+    fn insert_reasoning(&mut self, call_id: String, reasoning: String) {
+        if let Some(old) = self.reasoning.remove(&call_id) {
+            self.stored_bytes = self.stored_bytes.saturating_sub(old.bytes);
+        }
+        self.reasoning_order.retain(|key| key != &call_id);
+
+        let bytes = call_id.len().saturating_add(reasoning.len());
+        self.stored_bytes = self.stored_bytes.saturating_add(bytes);
+        self.reasoning.insert(
+            call_id.clone(),
+            StoredString {
+                value: reasoning,
+                bytes,
+                last_used_at: Instant::now(),
+            },
+        );
+        self.reasoning_order.push_back(call_id);
+    }
+
+    fn insert_turn_reasoning(&mut self, key: u64, reasoning: String) {
+        if let Some(old) = self.turn_reasoning.remove(&key) {
+            self.stored_bytes = self.stored_bytes.saturating_sub(old.bytes);
+        }
+        self.turn_reasoning_order
+            .retain(|existing| *existing != key);
+
+        let bytes = std::mem::size_of::<u64>().saturating_add(reasoning.len());
+        self.stored_bytes = self.stored_bytes.saturating_add(bytes);
+        self.turn_reasoning.insert(
+            key,
+            StoredString {
+                value: reasoning,
+                bytes,
+                last_used_at: Instant::now(),
+            },
+        );
+        self.turn_reasoning_order.push_back(key);
+    }
+
+    fn enforce_limits(&mut self) {
+        self.remove_expired();
+
+        while self.sessions.len() > self.max_sessions {
+            self.remove_oldest_session();
+        }
+
+        while self.stored_bytes > self.max_stored_bytes && self.sessions.len() > 1 {
+            self.remove_oldest_session();
+        }
+
+        while self.stored_bytes > self.max_stored_bytes && !self.reasoning_order.is_empty() {
+            self.remove_oldest_reasoning();
+        }
+
+        while self.stored_bytes > self.max_stored_bytes && !self.turn_reasoning_order.is_empty() {
+            self.remove_oldest_turn_reasoning();
+        }
+    }
+
+    fn remove_expired(&mut self) {
+        let cutoff = Instant::now() - self.ttl;
+
+        while self
+            .session_order
+            .front()
+            .and_then(|id| self.sessions.get(id))
+            .is_some_and(|entry| entry.last_used_at <= cutoff)
+        {
+            self.remove_oldest_session();
+        }
+
+        while self
+            .reasoning_order
+            .front()
+            .and_then(|id| self.reasoning.get(id))
+            .is_some_and(|entry| entry.last_used_at <= cutoff)
+        {
+            self.remove_oldest_reasoning();
+        }
+
+        while self
+            .turn_reasoning_order
+            .front()
+            .and_then(|key| self.turn_reasoning.get(key))
+            .is_some_and(|entry| entry.last_used_at <= cutoff)
+        {
+            self.remove_oldest_turn_reasoning();
+        }
+    }
+
+    fn remove_oldest_session(&mut self) {
+        if let Some(id) = self.session_order.pop_front() {
+            self.remove_session_entry(&id);
+        }
+    }
+
+    fn remove_session(&mut self, id: &str) {
+        self.session_order.retain(|existing| existing != id);
+        self.remove_session_entry(id);
+    }
+
+    fn remove_session_entry(&mut self, id: &str) {
+        if let Some(entry) = self.sessions.remove(id) {
+            self.stored_bytes = self.stored_bytes.saturating_sub(entry.bytes);
+        }
+    }
+
+    fn remove_oldest_reasoning(&mut self) {
+        if let Some(key) = self.reasoning_order.pop_front() {
+            if let Some(entry) = self.reasoning.remove(&key) {
+                self.stored_bytes = self.stored_bytes.saturating_sub(entry.bytes);
+            }
+        }
+    }
+
+    fn remove_oldest_turn_reasoning(&mut self) {
+        if let Some(key) = self.turn_reasoning_order.pop_front() {
+            if let Some(entry) = self.turn_reasoning.remove(&key) {
+                self.stored_bytes = self.stored_bytes.saturating_sub(entry.bytes);
+            }
+        }
+    }
+
+    fn touch_session(&mut self, id: &str) {
+        if let Some(entry) = self.sessions.get_mut(id) {
+            entry.last_used_at = Instant::now();
+        }
+        self.session_order.retain(|existing| existing != id);
+        self.session_order.push_back(id.to_string());
+    }
+
+    fn touch_reasoning(&mut self, call_id: &str) {
+        if let Some(entry) = self.reasoning.get_mut(call_id) {
+            entry.last_used_at = Instant::now();
+        }
+        self.reasoning_order.retain(|existing| existing != call_id);
+        self.reasoning_order.push_back(call_id.to_string());
+    }
+
+    fn touch_turn_reasoning(&mut self, key: u64) {
+        if let Some(entry) = self.turn_reasoning.get_mut(&key) {
+            entry.last_used_at = Instant::now();
+        }
+        self.turn_reasoning_order
+            .retain(|existing| *existing != key);
+        self.turn_reasoning_order.push_back(key);
+    }
+}
+
+fn messages_bytes(messages: &[ChatMessage]) -> usize {
+    messages.iter().map(message_bytes).sum()
+}
+
+fn message_bytes(message: &ChatMessage) -> usize {
+    message
+        .role
+        .len()
+        .saturating_add(
+            message
+                .content
+                .as_ref()
+                .map(value_bytes)
+                .unwrap_or_default(),
+        )
+        .saturating_add(
+            message
+                .reasoning_content
+                .as_ref()
+                .map(String::len)
+                .unwrap_or_default(),
+        )
+        .saturating_add(
+            message
+                .tool_calls
+                .as_ref()
+                .map(|calls| calls.iter().map(value_bytes).sum())
+                .unwrap_or_default(),
+        )
+        .saturating_add(
+            message
+                .tool_call_id
+                .as_ref()
+                .map(String::len)
+                .unwrap_or_default(),
+        )
+        .saturating_add(message.name.as_ref().map(String::len).unwrap_or_default())
+}
+
+fn value_bytes(value: &serde_json::Value) -> usize {
+    match value {
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => 8,
+        serde_json::Value::String(s) => s.len(),
+        serde_json::Value::Array(values) => values.iter().map(value_bytes).sum(),
+        serde_json::Value::Object(map) => map
+            .iter()
+            .map(|(key, value)| key.len().saturating_add(value_bytes(value)))
+            .sum(),
     }
 }
 
@@ -205,5 +528,79 @@ mod tests {
         assert_eq!(a, b);
         let c = SessionStore::content_key("different");
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_evicts_oldest_session_by_count() {
+        let store = SessionStore::with_limits(2, 1024);
+        let id1 = store.save(vec![msg("user", Some("one"))]);
+        let id2 = store.save(vec![msg("user", Some("two"))]);
+        let id3 = store.save(vec![msg("user", Some("three"))]);
+
+        assert!(store.get_history(&id1).is_empty());
+        assert_eq!(store.get_history(&id2).len(), 1);
+        assert_eq!(store.get_history(&id3).len(), 1);
+    }
+
+    #[test]
+    fn test_evicts_oldest_session_by_bytes() {
+        let store = SessionStore::with_limits(10, 64);
+        let id1 = store.save(vec![msg("user", Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))]);
+        let id2 = store.save(vec![msg("user", Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))]);
+        let id3 = store.save(vec![msg("user", Some("c"))]);
+
+        assert!(store.get_history(&id1).is_empty());
+        assert_eq!(store.get_history(&id2).len(), 1);
+        assert_eq!(store.get_history(&id3).len(), 1);
+    }
+
+    #[test]
+    fn test_oversized_session_not_cached() {
+        let store = SessionStore::with_limits(10, 10);
+        let id = store.save(vec![msg("user", Some("this message is too large"))]);
+        assert!(store.get_history(&id).is_empty());
+    }
+
+    #[test]
+    fn test_reasoning_entries_are_bounded_by_bytes() {
+        let store = SessionStore::with_limits(10, 36);
+        store.store_reasoning("call_1".into(), "aaaaaaaaaaaaaaaaaaaaaaaa".into());
+        store.store_reasoning("call_2".into(), "bbbbbbbbbbbbbbbbbbbbbbbb".into());
+
+        assert_eq!(store.get_reasoning("call_1"), None);
+        assert_eq!(
+            store.get_reasoning("call_2"),
+            Some("bbbbbbbbbbbbbbbbbbbbbbbb".into())
+        );
+    }
+
+    #[test]
+    fn test_cleanup_removes_expired_session() {
+        let store = SessionStore::with_limits_and_ttl(10, 1024, Duration::from_secs(60));
+        let id = store.save(vec![msg("user", Some("old"))]);
+
+        {
+            let mut state = store.state.lock().unwrap();
+            state.sessions.get_mut(&id).unwrap().last_used_at =
+                Instant::now() - Duration::from_secs(61);
+        }
+
+        store.cleanup();
+        assert!(store.get_history(&id).is_empty());
+    }
+
+    #[test]
+    fn test_cleanup_removes_expired_reasoning() {
+        let store = SessionStore::with_limits_and_ttl(10, 1024, Duration::from_secs(60));
+        store.store_reasoning("call_old".into(), "old thought".into());
+
+        {
+            let mut state = store.state.lock().unwrap();
+            state.reasoning.get_mut("call_old").unwrap().last_used_at =
+                Instant::now() - Duration::from_secs(61);
+        }
+
+        store.cleanup();
+        assert_eq!(store.get_reasoning("call_old"), None);
     }
 }


### PR DESCRIPTION
Fixes #8.

Bounds retained session/reasoning state with a one-week default TTL plus max-session and memory-budget safety rails. Adds cleanup and retention tests.

Validation: cargo test passes with local-port permission for the regression test.