### PR TITLE
[codex] Add opt-in tool denylist

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Any OpenAI-compatible endpoint works.
 | `CODEX_RELAY_UPSTREAM` | `https://openrouter.ai/api/v1` | Upstream Chat Completions base URL |
 | `CODEX_RELAY_API_KEY` | _(empty)_ | API key forwarded to upstream |
 | `CODEX_RELAY_MODEL_MAP` | _(empty)_ | Comma-separated `source:target` model name translations (e.g., `gpt-5.4:deepseek-v4-pro`) |
+| `CODEX_RELAY_TOOL_DENYLIST` | _(empty)_ | Comma-separated tool names to remove before forwarding tools to the upstream model |
 | `CODEX_RELAY_SESSION_TTL_HOURS` | `168` | Retain idle session/reasoning state for this many hours |
 | `CODEX_RELAY_MAX_SESSIONS` | `256` | Maximum completed response histories retained for `previous_response_id` |
 | `CODEX_RELAY_MAX_SESSION_MEMORY_MB` | `512` | Approximate memory budget for retained session/reasoning state |
@@ -156,6 +157,30 @@ The relay logs tool names only, never tool arguments or message content:
 These lines are useful for checking whether a tool such as `spawn_agent`
 was preserved by the relay, and whether the failure happened before or after
 the model selected that tool.
+
+### Subagent tool routing
+
+Codex subagent tools such as `spawn_agent`, `wait_agent`, and `close_agent`
+are runtime tools. The relay can preserve them in the tool schema and round-trip
+the model's selected function call, but it cannot reliably detect whether the
+local Codex app-server daemon is new enough to execute those calls.
+
+If Codex shows `unsupported call: spawn_agent`, first verify that the Codex CLI
+and app-server daemon versions match. A stale daemon can expose a newer tool
+schema to the model while lacking the handler that executes the returned call.
+Also check your Codex config: `[features] subagents = true` is not recognized;
+use `[features] multi_agent = true` only if you need to override the default.
+
+As an escape hatch for affected runtimes, remove unsupported tools before they
+reach the upstream model:
+
+```bash
+CODEX_RELAY_TOOL_DENYLIST=spawn_agent,wait_agent,close_agent codex-relay
+```
+
+The denylist matches the tool name forwarded to Chat Completions. Namespaced
+MCP tools use their flattened name, for example
+`mcp__codex_apps__github_fetch_issue`.
 
 **Offline (always green, default `cargo test`)**
 

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -233,10 +233,29 @@ fn map_model_name(name: &str) -> String {
 /// - `web_search`, `image_generation`, `computer`, `file_search`, … → drop;
 ///   non-OpenAI providers reject these built-ins.
 fn convert_tools(tools: &[Value]) -> Vec<Value> {
+    let denied = tool_denylist_from_env();
+    convert_tools_with_denylist(tools, &denied)
+}
+
+fn tool_denylist_from_env() -> HashSet<String> {
+    std::env::var("CODEX_RELAY_TOOL_DENYLIST")
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+fn convert_tools_with_denylist(tools: &[Value], denied: &HashSet<String>) -> Vec<Value> {
     let mut out: Vec<Value> = Vec::with_capacity(tools.len());
     for tool in tools {
         match tool.get("type").and_then(Value::as_str) {
-            Some("function") => out.push(convert_tool(tool)),
+            Some("function") => {
+                if !tool_is_denied(tool, None, denied) {
+                    out.push(convert_tool(tool));
+                }
+            }
             Some("namespace") => {
                 let namespace = tool.get("name").and_then(Value::as_str).unwrap_or("");
                 if let Some(subs) = tool.get("tools").and_then(Value::as_array) {
@@ -246,7 +265,9 @@ fn convert_tools(tools: &[Value]) -> Vec<Value> {
                                 .get("name")
                                 .and_then(Value::as_str)
                                 .map(|name| format!("{namespace}{name}"));
-                            out.push(convert_tool_with_name(sub, name.as_deref()));
+                            if !tool_is_denied(sub, name.as_deref(), denied) {
+                                out.push(convert_tool_with_name(sub, name.as_deref()));
+                            }
                         }
                     }
                 }
@@ -255,6 +276,22 @@ fn convert_tools(tools: &[Value]) -> Vec<Value> {
         }
     }
     out
+}
+
+fn tool_is_denied(tool: &Value, override_name: Option<&str>, denied: &HashSet<String>) -> bool {
+    if denied.is_empty() {
+        return false;
+    }
+    let name = override_name
+        .map(str::to_string)
+        .or_else(|| {
+            tool.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(Value::as_str)
+                .map(String::from)
+        })
+        .or_else(|| tool.get("name").and_then(Value::as_str).map(String::from));
+    name.is_some_and(|name| denied.contains(&name))
 }
 
 /// Responses API tool format → Chat Completions tool format.
@@ -625,6 +662,84 @@ mod tests {
         });
         let result = convert_tool(&already);
         assert_eq!(result, already);
+    }
+
+    #[test]
+    fn test_convert_tools_preserves_subagent_tools_without_denylist() {
+        let tools = vec![
+            json!({"type": "function", "name": "spawn_agent"}),
+            json!({"type": "function", "name": "wait_agent"}),
+        ];
+        let converted = convert_tools_with_denylist(&tools, &HashSet::new());
+        let names: Vec<&str> = converted
+            .iter()
+            .filter_map(|tool| {
+                tool.get("function")
+                    .and_then(|func| func.get("name"))
+                    .and_then(Value::as_str)
+            })
+            .collect();
+        assert_eq!(names, ["spawn_agent", "wait_agent"]);
+    }
+
+    #[test]
+    fn test_convert_tools_denylist_filters_flat_and_namespaced_tools() {
+        let tools = vec![
+            json!({"type": "function", "name": "spawn_agent"}),
+            json!({"type": "function", "name": "exec_command"}),
+            json!({
+                "type": "namespace",
+                "name": "mcp__server__",
+                "tools": [
+                    {"type": "function", "name": "blocked"},
+                    {"type": "function", "name": "allowed"}
+                ]
+            }),
+        ];
+        let denied = HashSet::from([
+            "spawn_agent".to_string(),
+            "mcp__server__blocked".to_string(),
+        ]);
+
+        let converted = convert_tools_with_denylist(&tools, &denied);
+        let names: Vec<&str> = converted
+            .iter()
+            .filter_map(|tool| {
+                tool.get("function")
+                    .and_then(|func| func.get("name"))
+                    .and_then(Value::as_str)
+            })
+            .collect();
+
+        assert_eq!(names, ["exec_command", "mcp__server__allowed"]);
+    }
+
+    #[test]
+    fn test_to_chat_request_honors_tool_denylist_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("CODEX_RELAY_TOOL_DENYLIST", "spawn_agent, wait_agent");
+
+        let sessions = SessionStore::new();
+        let mut req = base_req(ResponsesInput::Text("hello".into()));
+        req.tools = vec![
+            json!({"type": "function", "name": "spawn_agent"}),
+            json!({"type": "function", "name": "exec_command"}),
+            json!({"type": "function", "name": "wait_agent"}),
+        ];
+
+        let chat = to_chat_request(&req, vec![], &sessions);
+        let names: Vec<&str> = chat
+            .tools
+            .iter()
+            .filter_map(|tool| {
+                tool.get("function")
+                    .and_then(|func| func.get("name"))
+                    .and_then(Value::as_str)
+            })
+            .collect();
+
+        assert_eq!(names, ["exec_command"]);
+        std::env::remove_var("CODEX_RELAY_TOOL_DENYLIST");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an opt-in `CODEX_RELAY_TOOL_DENYLIST` escape hatch for runtimes that expose tools the local Codex dispatcher cannot execute.

## Why

Fixes #10 by addressing the relay-side mitigation/documentation gap without default-filtering subagent tools for users whose Codex runtime supports them.

## Changes

- Preserve `spawn_agent`/`wait_agent` by default when no denylist is configured.
- Filter flat and namespaced tools from the upstream Chat Completions schema when `CODEX_RELAY_TOOL_DENYLIST` is set.
- Document subagent routing prerequisites, stale app-server behavior, the unrecognized `subagents` feature key, and the denylist workaround.
- Add unit coverage for default preservation, flat/namespaced filtering, and env-var behavior.

## Validation

- `cargo fmt --check`
- `cargo test convert_tools`
- `cargo test tool_denylist`
- `cargo test`