### PR TITLE
[codex] fix spawn agent child context isolation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -276,10 +276,7 @@ async fn print_codex_config(client: &Client, upstream: &Url, api_key: &str, prov
     println!("wire_api = \"responses\"");
     println!(
         "env_key = \"{}_API_KEY\"",
-        provider_name
-            .to_uppercase()
-            .replace('-', "_")
-            .replace('.', "_")
+        provider_name.to_uppercase().replace(['-', '.'], "_")
     );
     println!();
 
@@ -335,11 +332,12 @@ fn estimate_model_properties(model_id: &str) -> ModelProps {
         (262_144, 1_048_576)
     } else if lower.contains("qwen") {
         (131_072, 131_072)
-    } else if lower.contains("kimi") || lower.contains("moonshot") {
-        (128_000, 128_000)
-    } else if lower.contains("mistral") {
-        (128_000, 128_000)
-    } else if lower.contains("llama") || lower.contains("codestral") {
+    } else if lower.contains("kimi")
+        || lower.contains("moonshot")
+        || lower.contains("mistral")
+        || lower.contains("llama")
+        || lower.contains("codestral")
+    {
         (128_000, 128_000)
     } else {
         // Conservative default for unknown models
@@ -526,14 +524,18 @@ async fn handle_responses(State(state): State<AppState>, body: axum::body::Bytes
 }
 
 async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Response {
-    let history = req
+    let mut history = req
         .previous_response_id
         .as_deref()
         .map(|id| state.sessions.get_history(id))
         .unwrap_or_default();
+    if should_isolate_spawn_child_request(&req, &history) {
+        debug!("isolating spawned child request from parent response history");
+        history.clear();
+    }
 
     let model = req.model.clone();
-    let mut chat_req = translate::to_chat_request(&req, history.clone(), &state.sessions);
+    let mut chat_req = translate::to_chat_request(&req, history, &state.sessions);
     debug!(
         "→ upstream tools={}",
         summarize_debug_names(chat_tool_debug_names(&chat_req.tools))
@@ -559,6 +561,67 @@ async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Respo
         chat_req.stream = false;
         handle_blocking(state, chat_req, url, model).await
     }
+}
+
+fn should_isolate_spawn_child_request(req: &ResponsesRequest, history: &[ChatMessage]) -> bool {
+    let Some(input_text) = isolated_user_text(&req.input) else {
+        return false;
+    };
+    let completed_tool_calls: std::collections::HashSet<&str> = history
+        .iter()
+        .filter_map(|msg| msg.tool_call_id.as_deref())
+        .collect();
+    history.iter().any(|msg| {
+        msg.tool_calls.as_deref().unwrap_or(&[]).iter().any(|call| {
+            let call_id = call.get("id").and_then(serde_json::Value::as_str);
+            call_id.is_none_or(|id| !completed_tool_calls.contains(id))
+                && spawn_agent_message(call).is_some_and(|message| message == input_text)
+        })
+    })
+}
+
+fn isolated_user_text(input: &ResponsesInput) -> Option<&str> {
+    match input {
+        ResponsesInput::Text(text) => Some(text.as_str()),
+        ResponsesInput::Messages(items) => {
+            if items.len() != 1 {
+                return None;
+            }
+            let item = &items[0];
+            if item.get("type").and_then(serde_json::Value::as_str) != Some("message")
+                || item.get("role").and_then(serde_json::Value::as_str) != Some("user")
+            {
+                return None;
+            }
+            match item.get("content") {
+                Some(serde_json::Value::String(text)) => Some(text.as_str()),
+                Some(serde_json::Value::Array(parts)) if parts.len() == 1 => {
+                    parts[0].get("text").and_then(serde_json::Value::as_str)
+                }
+                _ => None,
+            }
+        }
+    }
+}
+
+fn spawn_agent_message(call: &serde_json::Value) -> Option<String> {
+    if call
+        .get("function")
+        .and_then(|function| function.get("name"))
+        .and_then(serde_json::Value::as_str)
+        != Some("spawn_agent")
+    {
+        return None;
+    }
+    let arguments = call
+        .get("function")
+        .and_then(|function| function.get("arguments"))
+        .and_then(serde_json::Value::as_str)?;
+    let arguments: serde_json::Value = serde_json::from_str(arguments).ok()?;
+    arguments
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .map(String::from)
 }
 
 async fn handle_blocking(
@@ -729,6 +792,116 @@ mod tests {
             chat_response_tool_call_debug_names(&chat_resp),
             vec!["spawn_agent".to_string()]
         );
+    }
+
+    #[test]
+    fn test_spawn_child_request_isolated_when_input_matches_spawn_message() {
+        let req = ResponsesRequest {
+            model: "test".into(),
+            input: ResponsesInput::Text("child task".into()),
+            previous_response_id: Some("resp_parent".into()),
+            tools: vec![],
+            stream: false,
+            temperature: None,
+            max_output_tokens: None,
+            system: None,
+            instructions: None,
+        };
+        let history = vec![ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            reasoning_content: None,
+            tool_calls: Some(vec![json!({
+                "id": "call_spawn",
+                "type": "function",
+                "function": {
+                    "name": "spawn_agent",
+                    "arguments": "{\"task_name\":\"child\",\"message\":\"child task\"}"
+                }
+            })]),
+            tool_call_id: None,
+            name: None,
+        }];
+
+        assert!(should_isolate_spawn_child_request(&req, &history));
+    }
+
+    #[test]
+    fn test_spawn_child_isolation_does_not_match_tool_outputs() {
+        let req = ResponsesRequest {
+            model: "test".into(),
+            input: ResponsesInput::Messages(vec![json!({
+                "type": "function_call_output",
+                "call_id": "call_spawn",
+                "output": "child result"
+            })]),
+            previous_response_id: Some("resp_parent".into()),
+            tools: vec![],
+            stream: false,
+            temperature: None,
+            max_output_tokens: None,
+            system: None,
+            instructions: None,
+        };
+        let history = vec![ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            reasoning_content: None,
+            tool_calls: Some(vec![json!({
+                "id": "call_spawn",
+                "type": "function",
+                "function": {
+                    "name": "spawn_agent",
+                    "arguments": "{\"task_name\":\"child\",\"message\":\"child task\"}"
+                }
+            })]),
+            tool_call_id: None,
+            name: None,
+        }];
+
+        assert!(!should_isolate_spawn_child_request(&req, &history));
+    }
+
+    #[test]
+    fn test_spawn_child_isolation_ignores_completed_spawn_calls() {
+        let req = ResponsesRequest {
+            model: "test".into(),
+            input: ResponsesInput::Text("child task".into()),
+            previous_response_id: Some("resp_parent".into()),
+            tools: vec![],
+            stream: false,
+            temperature: None,
+            max_output_tokens: None,
+            system: None,
+            instructions: None,
+        };
+        let history = vec![
+            ChatMessage {
+                role: "assistant".into(),
+                content: None,
+                reasoning_content: None,
+                tool_calls: Some(vec![json!({
+                    "id": "call_spawn",
+                    "type": "function",
+                    "function": {
+                        "name": "spawn_agent",
+                        "arguments": "{\"task_name\":\"child\",\"message\":\"child task\"}"
+                    }
+                })]),
+                tool_call_id: None,
+                name: None,
+            },
+            ChatMessage {
+                role: "tool".into(),
+                content: Some(serde_json::Value::String("4".into())),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: Some("call_spawn".into()),
+                name: None,
+            },
+        ];
+
+        assert!(!should_isolate_spawn_child_request(&req, &history));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -212,6 +212,12 @@ impl SessionStore {
     }
 }
 
+impl Default for SessionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SessionState {
     fn insert_session(&mut self, id: String, messages: Vec<ChatMessage>) {
         let bytes = messages_bytes(&messages);

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -453,6 +453,7 @@ pub(crate) fn split_mcp_function_name(name: &str) -> (Option<String>, String) {
 ///     * `input_text` / `text`  → `{type:"text", text}`
 ///     * `input_image` (string) → `{type:"image_url", image_url:{url}}`
 ///     * `image_url`            → normalized to `{type:"image_url", image_url:{url}}`
+///
 ///   Unknown part types pass through; the upstream may reject them and the
 ///   relay propagates that error as-is.
 fn value_to_chat_content(v: Option<&Value>) -> Option<Value> {

--- a/tests/compat_deepseek_live.rs
+++ b/tests/compat_deepseek_live.rs
@@ -4,8 +4,7 @@
 //!   - DeepSeek models : deepseek-v4-pro, deepseek-v4-flash
 //!   - codex-relay     : current crate (see Cargo.toml `version`)
 //!   - Codex CLI       : not exercised — these tests speak the Responses API
-//!                       directly to the relay, simulating any Codex 0.128.x
-//!                       client.
+//!     directly to the relay, simulating any Codex 0.128.x client.
 //!
 //! Gated on `DEEPSEEK_API_KEY` env var. Each test is marked `#[ignore]`
 //! so the default `cargo test` stays offline. To run:

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -17,6 +17,7 @@ use codex_relay::types::ResponsesRequest;
 use eventsource_stream::Eventsource;
 use futures_util::StreamExt;
 use serde_json::{json, Value};
+use std::collections::VecDeque;
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -68,6 +69,7 @@ fn issue_6_namespace_tools_keep_namespace_when_flattened() {
 #[derive(Clone)]
 struct MockState {
     bodies: Arc<Mutex<Vec<Value>>>,
+    responses: Arc<Mutex<VecDeque<String>>>,
 }
 
 async fn models_handler() -> axum::Json<Value> {
@@ -87,11 +89,12 @@ async fn chat_handler(State(state): State<MockState>, req: axum::extract::Reques
     let body: Value = serde_json::from_slice(&bytes).expect("chat request json");
     state.bodies.lock().unwrap().push(body);
 
-    let sse = concat!(
-        "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"OK\"}}]}\n\n",
-        "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":2,\"total_tokens\":9}}\n\n",
-        "data: [DONE]\n\n",
-    );
+    let sse = state
+        .responses
+        .lock()
+        .unwrap()
+        .pop_front()
+        .unwrap_or_else(default_ok_sse);
 
     Response::builder()
         .status(StatusCode::OK)
@@ -100,11 +103,36 @@ async fn chat_handler(State(state): State<MockState>, req: axum::extract::Reques
         .unwrap()
 }
 
+fn sse_from_chunks(chunks: Vec<Value>) -> String {
+    let mut sse = String::new();
+    for chunk in chunks {
+        sse.push_str("data: ");
+        sse.push_str(&chunk.to_string());
+        sse.push_str("\n\n");
+    }
+    sse.push_str("data: [DONE]\n\n");
+    sse
+}
+
+fn default_ok_sse() -> String {
+    sse_from_chunks(vec![
+        json!({"choices":[{"delta":{"role":"assistant","content":"OK"}}]}),
+        json!({"choices":[],"usage":{"prompt_tokens":7,"completion_tokens":2,"total_tokens":9}}),
+    ])
+}
+
 async fn spawn_mock_upstream() -> (u16, Arc<Mutex<Vec<Value>>>) {
+    spawn_mock_upstream_with_responses(Vec::new()).await
+}
+
+async fn spawn_mock_upstream_with_responses(
+    responses: Vec<String>,
+) -> (u16, Arc<Mutex<Vec<Value>>>) {
     let port = pick_port();
     let bodies = Arc::new(Mutex::new(Vec::new()));
     let state = MockState {
         bodies: bodies.clone(),
+        responses: Arc::new(Mutex::new(VecDeque::from(responses))),
     };
     let app = Router::new()
         .route("/v1/models", get(models_handler))
@@ -119,6 +147,30 @@ async fn spawn_mock_upstream() -> (u16, Arc<Mutex<Vec<Value>>>) {
             .expect("mock upstream serve");
     });
     (port, bodies)
+}
+
+async fn post_stream_completed(relay: &Relay, body: Value) -> Value {
+    let resp = reqwest::Client::new()
+        .post(relay.url("/v1/responses"))
+        .json(&body)
+        .send()
+        .await
+        .expect("POST /v1/responses");
+    assert!(resp.status().is_success(), "status {}", resp.status());
+
+    let mut events = resp.bytes_stream().eventsource();
+    let deadline = Instant::now() + Duration::from_secs(8);
+    while let Some(ev) = tokio::time::timeout(deadline - Instant::now(), events.next())
+        .await
+        .expect("stream timeout")
+    {
+        let ev = ev.expect("sse parse");
+        if ev.event == "response.completed" {
+            return serde_json::from_str(&ev.data).expect("completed json");
+        }
+    }
+
+    panic!("response.completed event");
 }
 
 struct Relay {
@@ -214,5 +266,109 @@ async fn issue_5_streaming_completed_event_includes_usage() {
         upstream_body["stream_options"],
         json!({"include_usage": true}),
         "streaming Chat Completions requests must ask upstream to include usage"
+    );
+}
+
+#[tokio::test]
+async fn issue_12_spawn_agent_child_context_should_not_replay_parent_history() {
+    let child_task = "Please compute 2+2 and return only the numeric result.";
+    let parent_prompt = "Ask a subagent to solve 2+2.";
+    let tool_args = json!({
+        "task_name": "simple_math",
+        "message": child_task,
+    })
+    .to_string();
+    let spawn_agent_sse = sse_from_chunks(vec![
+        json!({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_spawn_simple_math",
+                        "function": {
+                            "name": "spawn_agent",
+                            "arguments": tool_args
+                        }
+                    }]
+                }
+            }]
+        }),
+        json!({"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":3,"total_tokens":14}}),
+    ]);
+
+    let (upstream_port, bodies) =
+        spawn_mock_upstream_with_responses(vec![spawn_agent_sse, default_ok_sse()]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let parent_completed = post_stream_completed(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "instructions": "You are the parent agent.",
+            "input": parent_prompt,
+            "tools": [{"type": "function", "name": "spawn_agent"}],
+            "stream": true
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        parent_completed["response"]["output"][0]["name"], "spawn_agent",
+        "mock upstream should first drive a spawn_agent call"
+    );
+    let parent_response_id = parent_completed["response"]["id"]
+        .as_str()
+        .expect("parent response id");
+
+    // Simulate the child agent request that triggers #12: it asks the relay
+    // for the spawned task while also reusing the parent's previous_response_id.
+    // A correctly isolated child thread should send only the child task context
+    // upstream, not the parent's prompt or assistant spawn_agent tool call.
+    let _child_completed = post_stream_completed(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "instructions": "You are the spawned child agent.",
+            "previous_response_id": parent_response_id,
+            "input": child_task,
+            "tools": [
+                {"type": "function", "name": "spawn_agent"},
+                {"type": "function", "name": "wait_agent"}
+            ],
+            "stream": true
+        }),
+    )
+    .await;
+
+    let request_bodies = bodies.lock().unwrap();
+    assert_eq!(request_bodies.len(), 2, "parent and child upstream calls");
+    let child_messages = request_bodies[1]["messages"]
+        .as_array()
+        .expect("child upstream messages");
+
+    assert!(
+        !child_messages
+            .iter()
+            .any(|msg| msg["content"] == parent_prompt),
+        "child upstream request leaked the parent prompt: {child_messages:#?}"
+    );
+    assert!(
+        !child_messages.iter().any(|msg| {
+            msg["tool_calls"].as_array().is_some_and(|calls| {
+                calls
+                    .iter()
+                    .any(|call| call["function"]["name"] == "spawn_agent")
+            })
+        }),
+        "child upstream request replayed the parent's spawn_agent tool call: {child_messages:#?}"
+    );
+    assert_eq!(
+        child_messages
+            .iter()
+            .filter(|msg| msg["role"] == "user")
+            .map(|msg| msg["content"].as_str().unwrap_or(""))
+            .collect::<Vec<_>>(),
+        vec![child_task],
+        "child upstream request should contain exactly the spawned message as user input"
     );
 }


### PR DESCRIPTION
## Summary

Fixes the spawn-agent child context leak reported in #12.

When a request reuses `previous_response_id`, the relay now detects spawned child first-turn requests by matching the current user input against an unresolved parent `spawn_agent` call's `message` argument. For those child requests, it skips replaying the parent response history before translating to Chat Completions.

This prevents the child upstream request from receiving the parent prompt and parent `spawn_agent` tool call, which was causing recursive subagent spawning.

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

## Notes

Also includes small clippy-only cleanups needed for the stricter guardrail command to pass.
