### PR TITLE
[codex] fix namespace tool routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ CODEX_RELAY_TOOL_DENYLIST=spawn_agent,wait_agent,close_agent codex-relay
 
 The denylist matches the tool name forwarded to Chat Completions. Namespaced
 MCP tools use their flattened name, for example
-`mcp__codex_apps__github_fetch_issue`.
+`mcp__codex_apps__github._fetch_issue`.
 
 **Offline (always green, default `cargo test`)**
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -474,7 +474,11 @@ fn response_tool_debug_names(tools: &[serde_json::Value]) -> Vec<String> {
                         if sub.get("type").and_then(serde_json::Value::as_str) == Some("function") {
                             if let Some(name) = sub.get("name").and_then(serde_json::Value::as_str)
                             {
-                                names.push(format!("{namespace}{name}"));
+                                names.push(
+                                    crate::translate::chat_function_name_for_namespace_tool(
+                                        namespace, name,
+                                    ),
+                                );
                             }
                         }
                     }
@@ -783,7 +787,7 @@ mod tests {
             response_tool_debug_names(&tools),
             vec![
                 "spawn_agent".to_string(),
-                "mcp__codex_apps__github_fetch_issue".to_string(),
+                "mcp__codex_apps__github._fetch_issue".to_string(),
                 "<web_search>".to_string(),
             ]
         );

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -264,7 +264,7 @@ fn convert_tools_with_denylist(tools: &[Value], denied: &HashSet<String>) -> Vec
                             let name = sub
                                 .get("name")
                                 .and_then(Value::as_str)
-                                .map(|name| format!("{namespace}{name}"));
+                                .map(|name| chat_function_name_for_namespace_tool(namespace, name));
                             if !tool_is_denied(sub, name.as_deref(), denied) {
                                 out.push(convert_tool_with_name(sub, name.as_deref()));
                             }
@@ -344,7 +344,15 @@ fn convert_tool_with_name(tool: &Value, override_name: Option<&str>) -> Value {
 fn response_function_name_for_chat(item: &Value) -> String {
     let name = item.get("name").and_then(Value::as_str).unwrap_or("");
     let namespace = item.get("namespace").and_then(Value::as_str).unwrap_or("");
-    format!("{namespace}{name}")
+    if namespace.is_empty() {
+        name.to_string()
+    } else {
+        chat_function_name_for_namespace_tool(namespace, name)
+    }
+}
+
+pub(crate) fn chat_function_name_for_namespace_tool(namespace: &str, name: &str) -> String {
+    format!("{namespace}.{name}")
 }
 
 /// Convert a Chat Completions response into a Responses API response.
@@ -426,6 +434,12 @@ pub fn from_chat_response(
 }
 
 pub(crate) fn split_mcp_function_name(name: &str) -> (Option<String>, String) {
+    if let Some((namespace, child)) = name.split_once('.') {
+        if !namespace.is_empty() && !child.is_empty() {
+            return (Some(namespace.to_string()), child.to_string());
+        }
+    }
+
     let Some(rest) = name.strip_prefix("mcp__") else {
         return (None, name.to_string());
     };
@@ -586,7 +600,7 @@ mod tests {
         let req = base_req(ResponsesInput::Messages(vec![json!({
             "type": "function_call",
             "call_id": "call_status",
-            "namespace": "mcp__burp_ai_agent__",
+            "namespace": "mcp__node_repl",
             "name": "status",
             "arguments": "{}"
         })]));
@@ -594,7 +608,7 @@ mod tests {
         let calls = chat.messages[0].tool_calls.as_ref().unwrap();
         assert_eq!(
             calls[0]["function"]["name"].as_str(),
-            Some("mcp__burp_ai_agent__status")
+            Some("mcp__node_repl.status")
         );
     }
 
@@ -610,7 +624,7 @@ mod tests {
                         "id": "call_status",
                         "type": "function",
                         "function": {
-                            "name": "mcp__burp_ai_agent__status",
+                            "name": "mcp__node_repl.status",
                             "arguments": "{}"
                         }
                     })]),
@@ -624,9 +638,37 @@ mod tests {
         let (resp, _) = from_chat_response("resp_1".into(), "test-model", chat);
         assert_eq!(resp.output.len(), 1);
         assert_eq!(resp.output[0]["type"], "function_call");
-        assert_eq!(resp.output[0]["namespace"], "mcp__burp_ai_agent__");
+        assert_eq!(resp.output[0]["namespace"], "mcp__node_repl");
         assert_eq!(resp.output[0]["name"], "status");
         assert_eq!(resp.output[0]["call_id"], "call_status");
+    }
+
+    #[test]
+    fn test_from_chat_response_keeps_legacy_non_namespaced_tool_name() {
+        let chat = ChatResponse {
+            choices: vec![ChatChoice {
+                message: ChatMessage {
+                    role: "assistant".into(),
+                    content: None,
+                    reasoning_content: None,
+                    tool_calls: Some(vec![json!({
+                        "id": "call_status",
+                        "type": "function",
+                        "function": {
+                            "name": "mcp__node_repljs",
+                            "arguments": "{}"
+                        }
+                    })]),
+                    tool_call_id: None,
+                    name: None,
+                },
+            }],
+            usage: None,
+        };
+
+        let (resp, _) = from_chat_response("resp_1".into(), "test-model", chat);
+        assert!(resp.output[0].get("namespace").is_none());
+        assert_eq!(resp.output[0]["name"], "mcp__node_repljs");
     }
 
     #[test]
@@ -690,17 +732,14 @@ mod tests {
             json!({"type": "function", "name": "exec_command"}),
             json!({
                 "type": "namespace",
-                "name": "mcp__server__",
+                "name": "mcp__server",
                 "tools": [
                     {"type": "function", "name": "blocked"},
                     {"type": "function", "name": "allowed"}
                 ]
             }),
         ];
-        let denied = HashSet::from([
-            "spawn_agent".to_string(),
-            "mcp__server__blocked".to_string(),
-        ]);
+        let denied = HashSet::from(["spawn_agent".to_string(), "mcp__server.blocked".to_string()]);
 
         let converted = convert_tools_with_denylist(&tools, &denied);
         let names: Vec<&str> = converted
@@ -712,7 +751,7 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(names, ["exec_command", "mcp__server__allowed"]);
+        assert_eq!(names, ["exec_command", "mcp__server.allowed"]);
     }
 
     #[test]

--- a/tests/compat_codex_0_128.rs
+++ b/tests/compat_codex_0_128.rs
@@ -57,8 +57,8 @@ fn namespace_tools_are_flattened() {
         names,
         vec![
             "exec_command",
-            "mcp__codex_apps__github_add_comment_to_issue",
-            "mcp__codex_apps__github_close_issue"
+            "mcp__codex_apps__github._add_comment_to_issue",
+            "mcp__codex_apps__github._close_issue"
         ]
     );
 

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -12,8 +12,8 @@ use axum::{
     Router,
 };
 use codex_relay::session::SessionStore;
-use codex_relay::translate::to_chat_request;
-use codex_relay::types::ResponsesRequest;
+use codex_relay::translate::{from_chat_response, to_chat_request};
+use codex_relay::types::{ChatChoice, ChatMessage, ChatResponse, ResponsesRequest};
 use eventsource_stream::Eventsource;
 use futures_util::StreamExt;
 use serde_json::{json, Value};
@@ -61,9 +61,38 @@ fn issue_6_namespace_tools_keep_namespace_when_flattened() {
     assert!(
         names
             .iter()
-            .any(|n| n == "mcp__codex_apps__github_add_comment_to_issue"),
+            .any(|n| n == "mcp__codex_apps__github._add_comment_to_issue"),
         "namespace child tool should be flattened with its namespace prefix: {names:?}"
     );
+}
+
+#[test]
+fn issue_17_blocking_namespaced_tool_calls_emit_namespace_field() {
+    let chat = ChatResponse {
+        choices: vec![ChatChoice {
+            message: ChatMessage {
+                role: "assistant".into(),
+                content: None,
+                reasoning_content: None,
+                tool_calls: Some(vec![json!({
+                    "id": "call_js",
+                    "type": "function",
+                    "function": {
+                        "name": "mcp__node_repl.js",
+                        "arguments": "{}"
+                    }
+                })]),
+                tool_call_id: None,
+                name: None,
+            },
+        }],
+        usage: None,
+    };
+
+    let (resp, _) = from_chat_response("resp_17".into(), "mock-model", chat);
+    assert_eq!(resp.output[0]["type"], "function_call");
+    assert_eq!(resp.output[0]["namespace"], "mcp__node_repl");
+    assert_eq!(resp.output[0]["name"], "js");
 }
 
 #[derive(Clone)]
@@ -266,6 +295,59 @@ async fn issue_5_streaming_completed_event_includes_usage() {
         upstream_body["stream_options"],
         json!({"include_usage": true}),
         "streaming Chat Completions requests must ask upstream to include usage"
+    );
+}
+
+#[tokio::test]
+async fn issue_17_streaming_namespaced_tool_calls_emit_namespace_field() {
+    let tool_sse = sse_from_chunks(vec![
+        json!({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_js",
+                        "function": {
+                            "name": "mcp__node_repl.js",
+                            "arguments": "{}"
+                        }
+                    }]
+                }
+            }]
+        }),
+        json!({"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":3,"total_tokens":14}}),
+    ]);
+    let (upstream_port, bodies) = spawn_mock_upstream_with_responses(vec![tool_sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let completed = post_stream_completed(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "input": "Use the JS REPL.",
+            "tools": [{
+                "type": "namespace",
+                "name": "mcp__node_repl",
+                "tools": [{
+                    "type": "function",
+                    "name": "js",
+                    "parameters": {"type": "object"}
+                }]
+            }],
+            "stream": true
+        }),
+    )
+    .await;
+
+    let item = &completed["response"]["output"][0];
+    assert_eq!(item["type"], "function_call");
+    assert_eq!(item["namespace"], "mcp__node_repl");
+    assert_eq!(item["name"], "js");
+
+    let request_bodies = bodies.lock().unwrap();
+    assert_eq!(
+        request_bodies[0]["tools"][0]["function"]["name"], "mcp__node_repl.js",
+        "namespace tools must be flattened with a reversible separator"
     );
 }
 


### PR DESCRIPTION
## Summary

Fix namespace tool routing across the Responses API and Chat Completions translation paths.

## Root Cause

Namespace tools were flattened by directly concatenating the namespace and child tool name. That made names like mcp__node_repljs ambiguous and prevented the relay from restoring the Responses API shape with namespace plus child name.

## Changes

- Flatten namespace tools with a reversible namespace.child name for Chat Completions.
- Restore namespace and child name when translating Chat Completions tool calls back to Responses output items.
- Apply the same naming helper to debug output and denylist documentation.
- Add blocking and streaming regression coverage for issue #17.

## Validation

- cargo fmt -- --check
- cargo test