### PR TITLE
fix: use charset-legal '-' separator for namespace tool names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -787,7 +787,7 @@ mod tests {
             response_tool_debug_names(&tools),
             vec![
                 "spawn_agent".to_string(),
-                "mcp__codex_apps__github._fetch_issue".to_string(),
+                "mcp__codex_apps__github-_fetch_issue".to_string(),
                 "<web_search>".to_string(),
             ]
         );

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -352,7 +352,12 @@ fn response_function_name_for_chat(item: &Value) -> String {
 }
 
 pub(crate) fn chat_function_name_for_namespace_tool(namespace: &str, name: &str) -> String {
-    format!("{namespace}.{name}")
+    // The Responses API tool-name charset is `^[a-zA-Z0-9_-]+$`, which excludes
+    // `.`. Codex's sanitizer collapses every other character (including `-`) to
+    // `_`, so `-` never appears inside a sanitized namespace or tool name. That
+    // makes it a charset-legal, unambiguously reversible separator: see
+    // `split_mcp_function_name`, which splits on the first `-`.
+    format!("{namespace}-{name}")
 }
 
 /// Convert a Chat Completions response into a Responses API response.
@@ -434,7 +439,7 @@ pub fn from_chat_response(
 }
 
 pub(crate) fn split_mcp_function_name(name: &str) -> (Option<String>, String) {
-    if let Some((namespace, child)) = name.split_once('.') {
+    if let Some((namespace, child)) = name.split_once('-') {
         if !namespace.is_empty() && !child.is_empty() {
             return (Some(namespace.to_string()), child.to_string());
         }
@@ -608,7 +613,7 @@ mod tests {
         let calls = chat.messages[0].tool_calls.as_ref().unwrap();
         assert_eq!(
             calls[0]["function"]["name"].as_str(),
-            Some("mcp__node_repl.status")
+            Some("mcp__node_repl-status")
         );
     }
 
@@ -624,7 +629,7 @@ mod tests {
                         "id": "call_status",
                         "type": "function",
                         "function": {
-                            "name": "mcp__node_repl.status",
+                            "name": "mcp__node_repl-status",
                             "arguments": "{}"
                         }
                     })]),
@@ -739,7 +744,7 @@ mod tests {
                 ]
             }),
         ];
-        let denied = HashSet::from(["spawn_agent".to_string(), "mcp__server.blocked".to_string()]);
+        let denied = HashSet::from(["spawn_agent".to_string(), "mcp__server-blocked".to_string()]);
 
         let converted = convert_tools_with_denylist(&tools, &denied);
         let names: Vec<&str> = converted
@@ -751,7 +756,7 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(names, ["exec_command", "mcp__server.allowed"]);
+        assert_eq!(names, ["exec_command", "mcp__server-allowed"]);
     }
 
     #[test]

--- a/tests/compat_codex_0_128.rs
+++ b/tests/compat_codex_0_128.rs
@@ -57,8 +57,8 @@ fn namespace_tools_are_flattened() {
         names,
         vec![
             "exec_command",
-            "mcp__codex_apps__github._add_comment_to_issue",
-            "mcp__codex_apps__github._close_issue"
+            "mcp__codex_apps__github-_add_comment_to_issue",
+            "mcp__codex_apps__github-_close_issue"
         ]
     );
 

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -61,7 +61,7 @@ fn issue_6_namespace_tools_keep_namespace_when_flattened() {
     assert!(
         names
             .iter()
-            .any(|n| n == "mcp__codex_apps__github._add_comment_to_issue"),
+            .any(|n| n == "mcp__codex_apps__github-_add_comment_to_issue"),
         "namespace child tool should be flattened with its namespace prefix: {names:?}"
     );
 }
@@ -78,7 +78,7 @@ fn issue_17_blocking_namespaced_tool_calls_emit_namespace_field() {
                     "id": "call_js",
                     "type": "function",
                     "function": {
-                        "name": "mcp__node_repl.js",
+                        "name": "mcp__node_repl-js",
                         "arguments": "{}"
                     }
                 })]),
@@ -308,7 +308,7 @@ async fn issue_17_streaming_namespaced_tool_calls_emit_namespace_field() {
                         "index": 0,
                         "id": "call_js",
                         "function": {
-                            "name": "mcp__node_repl.js",
+                            "name": "mcp__node_repl-js",
                             "arguments": "{}"
                         }
                     }]
@@ -346,7 +346,7 @@ async fn issue_17_streaming_namespaced_tool_calls_emit_namespace_field() {
 
     let request_bodies = bodies.lock().unwrap();
     assert_eq!(
-        request_bodies[0]["tools"][0]["function"]["name"], "mcp__node_repl.js",
+        request_bodies[0]["tools"][0]["function"]["name"], "mcp__node_repl-js",
         "namespace tools must be flattened with a reversible separator"
     );
 }


### PR DESCRIPTION
v0.3.0 ("fix namespace tool routing") joined an MCP namespace and its tool name with a literal `.` (e.g. `mcp__codegraph.codegraph_node`). The Responses API tool-name charset is `^[a-zA-Z0-9_-]+$`, which does not allow `.`, so spec-compliant upstreams (DeepSeek, OpenAI) reject every request that advertises a namespaced tool:

    400 Invalid 'tools[N].function.name': string does not match
    pattern. Expected a string that matches '^[a-zA-Z0-9_-]+$'.

Switch the separator to `-`, which is in the allowed charset. Codex's own sanitizer (`sanitize_responses_api_tool_name`) collapses every character outside `[a-zA-Z0-9_]` to `_`, so `-` never appears inside a sanitized namespace or tool name. That keeps the separator unambiguously reversible: `split_mcp_function_name` splits on the first `-`, which correctly recovers both single-segment (`mcp__codegraph`) and multi-segment (`mcp__codex_apps__github`) namespaces, preserving the routing fix from #18.

Tests updated to assert the `-` separator on both the request (join) and response (split) paths.