### PR TITLE
[codex] fix namespace tool decoding with request map

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ CODEX_RELAY_TOOL_DENYLIST=spawn_agent,wait_agent,close_agent codex-relay
 
 The denylist matches the tool name forwarded to Chat Completions. Namespaced
 MCP tools use their flattened name, for example
-`mcp__codex_apps__github._fetch_issue`.
+`mcp__codex_apps__github-_fetch_issue`.
 
 **Offline (always green, default `cargo test`)**
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -563,6 +563,7 @@ async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Respo
     }
 
     let model = req.model.clone();
+    let namespace_tools = translate::namespace_tool_map(&req.tools);
     let mut chat_req = translate::to_chat_request(&req, history, &state.sessions);
     debug!(
         "→ upstream tools={}",
@@ -582,12 +583,13 @@ async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Respo
             response_id,
             sessions: state.sessions,
             request_messages,
+            namespace_tools,
             model,
         })
         .into_response()
     } else {
         chat_req.stream = false;
-        handle_blocking(state, chat_req, url, model).await
+        handle_blocking(state, chat_req, url, model, namespace_tools).await
     }
 }
 
@@ -657,6 +659,7 @@ async fn handle_blocking(
     chat_req: types::ChatRequest,
     url: String,
     model: String,
+    namespace_tools: translate::NamespaceToolMap,
 ) -> Response {
     let mut builder = state
         .client
@@ -709,7 +712,16 @@ async fn handle_blocking(
                 full_history.push(assistant_msg);
                 let response_id = state.sessions.save(full_history);
 
-                let (resp, _) = translate::from_chat_response(response_id, &model, chat_resp);
+                let (resp, _) = if namespace_tools.is_empty() {
+                    translate::from_chat_response(response_id, &model, chat_resp)
+                } else {
+                    translate::from_chat_response_with_tool_map(
+                        response_id,
+                        &model,
+                        chat_resp,
+                        &namespace_tools,
+                    )
+                };
                 Json(resp).into_response()
             }
         },
@@ -787,7 +799,7 @@ mod tests {
             response_tool_debug_names(&tools),
             vec![
                 "spawn_agent".to_string(),
-                "mcp__codex_apps__github._fetch_issue".to_string(),
+                "mcp__codex_apps__github-_fetch_issue".to_string(),
                 "<web_search>".to_string(),
             ]
         );

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -12,7 +12,7 @@ use tracing::{debug, error, warn};
 
 use crate::{
     session::SessionStore,
-    translate::split_mcp_function_name,
+    translate::{response_function_name_for_responses, NamespaceToolMap},
     types::{ChatMessage, ChatRequest, ChatStreamChunk, ChatUsage},
 };
 
@@ -27,6 +27,7 @@ pub struct StreamArgs {
     /// Used to save correct session history so turn-level reasoning can be
     /// recovered when Codex replays the conversation without previous_response_id.
     pub request_messages: Vec<ChatMessage>,
+    pub namespace_tools: NamespaceToolMap,
     pub model: String,
 }
 
@@ -68,6 +69,7 @@ pub fn translate_stream(
         response_id,
         sessions,
         request_messages,
+        namespace_tools,
         model,
     } = args;
     let msg_item_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
@@ -229,7 +231,7 @@ pub fn translate_stream(
         for (rel_idx, (_, tc)) in tool_calls.iter().enumerate() {
             let fc_item_id = format!("fc_{}", uuid::Uuid::new_v4().simple());
             let output_index = base_index + rel_idx;
-            let (namespace, name) = split_mcp_function_name(&tc.name);
+            let (namespace, name) = response_function_name_for_responses(&tc.name, &namespace_tools);
             let mut added_item = json!({
                 "type": "function_call",
                 "id": &fc_item_id,

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -1,7 +1,15 @@
 use serde_json::{json, Value};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::{session::SessionStore, types::*};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespaceToolName {
+    pub namespace: String,
+    pub name: String,
+}
+
+pub type NamespaceToolMap = HashMap<String, NamespaceToolName>;
 
 /// Convert a Responses API request + prior history into a Chat Completions request.
 pub fn to_chat_request(
@@ -237,6 +245,38 @@ fn convert_tools(tools: &[Value]) -> Vec<Value> {
     convert_tools_with_denylist(tools, &denied)
 }
 
+pub fn namespace_tool_map(tools: &[Value]) -> NamespaceToolMap {
+    let mut map = NamespaceToolMap::new();
+    for tool in tools {
+        if tool.get("type").and_then(Value::as_str) != Some("namespace") {
+            continue;
+        }
+        let Some(namespace) = tool.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(subs) = tool.get("tools").and_then(Value::as_array) else {
+            continue;
+        };
+        for sub in subs {
+            if sub.get("type").and_then(Value::as_str) != Some("function") {
+                continue;
+            }
+            let Some(name) = sub.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let chat_name = chat_function_name_for_namespace_tool(namespace, name);
+            map.insert(
+                chat_name,
+                NamespaceToolName {
+                    namespace: namespace.to_string(),
+                    name: name.to_string(),
+                },
+            );
+        }
+    }
+    map
+}
+
 fn tool_denylist_from_env() -> HashSet<String> {
     std::env::var("CODEX_RELAY_TOOL_DENYLIST")
         .unwrap_or_default()
@@ -352,7 +392,10 @@ fn response_function_name_for_chat(item: &Value) -> String {
 }
 
 pub(crate) fn chat_function_name_for_namespace_tool(namespace: &str, name: &str) -> String {
-    format!("{namespace}.{name}")
+    // Chat Completions tool names must match `^[a-zA-Z0-9_-]+$`, so `.` is not
+    // accepted by strict upstreams. Decoding must use NamespaceToolMap whenever
+    // request tools are available; the separator alone is not authoritative.
+    format!("{namespace}-{name}")
 }
 
 /// Convert a Chat Completions response into a Responses API response.
@@ -360,6 +403,15 @@ pub fn from_chat_response(
     id: String,
     model: &str,
     chat: ChatResponse,
+) -> (ResponsesResponse, Vec<ChatMessage>) {
+    from_chat_response_with_tool_map(id, model, chat, &NamespaceToolMap::new())
+}
+
+pub fn from_chat_response_with_tool_map(
+    id: String,
+    model: &str,
+    chat: ChatResponse,
+    namespace_tools: &NamespaceToolMap,
 ) -> (ResponsesResponse, Vec<ChatMessage>) {
     let choice = chat
         .choices
@@ -395,7 +447,7 @@ pub fn from_chat_response(
         for tool_call in tool_calls {
             let function = tool_call.get("function").unwrap_or(&Value::Null);
             let raw_name = function.get("name").and_then(Value::as_str).unwrap_or("");
-            let (namespace, name) = split_mcp_function_name(raw_name);
+            let (namespace, name) = response_function_name_for_responses(raw_name, namespace_tools);
             let arguments = function
                 .get("arguments")
                 .and_then(Value::as_str)
@@ -431,6 +483,16 @@ pub fn from_chat_response(
     };
 
     (response, vec![choice.message])
+}
+
+pub(crate) fn response_function_name_for_responses(
+    name: &str,
+    namespace_tools: &NamespaceToolMap,
+) -> (Option<String>, String) {
+    if let Some(tool_name) = namespace_tools.get(name) {
+        return (Some(tool_name.namespace.clone()), tool_name.name.clone());
+    }
+    split_mcp_function_name(name)
 }
 
 pub(crate) fn split_mcp_function_name(name: &str) -> (Option<String>, String) {
@@ -608,12 +670,12 @@ mod tests {
         let calls = chat.messages[0].tool_calls.as_ref().unwrap();
         assert_eq!(
             calls[0]["function"]["name"].as_str(),
-            Some("mcp__node_repl.status")
+            Some("mcp__node_repl-status")
         );
     }
 
     #[test]
-    fn test_from_chat_response_splits_mcp_function_call_namespace() {
+    fn test_from_chat_response_uses_request_tool_map_for_namespace() {
         let chat = ChatResponse {
             choices: vec![ChatChoice {
                 message: ChatMessage {
@@ -624,7 +686,45 @@ mod tests {
                         "id": "call_status",
                         "type": "function",
                         "function": {
-                            "name": "mcp__node_repl.status",
+                            "name": "mcp__node_repl-status",
+                            "arguments": "{}"
+                        }
+                    })]),
+                    tool_call_id: None,
+                    name: None,
+                },
+            }],
+            usage: None,
+        };
+        let tools = vec![json!({
+            "type": "namespace",
+            "name": "mcp__node_repl",
+            "tools": [{"type": "function", "name": "status"}]
+        })];
+        let namespace_tools = namespace_tool_map(&tools);
+
+        let (resp, _) =
+            from_chat_response_with_tool_map("resp_1".into(), "test-model", chat, &namespace_tools);
+        assert_eq!(resp.output.len(), 1);
+        assert_eq!(resp.output[0]["type"], "function_call");
+        assert_eq!(resp.output[0]["namespace"], "mcp__node_repl");
+        assert_eq!(resp.output[0]["name"], "status");
+        assert_eq!(resp.output[0]["call_id"], "call_status");
+    }
+
+    #[test]
+    fn test_from_chat_response_preserves_hyphen_flat_tool_name() {
+        let chat = ChatResponse {
+            choices: vec![ChatChoice {
+                message: ChatMessage {
+                    role: "assistant".into(),
+                    content: None,
+                    reasoning_content: None,
+                    tool_calls: Some(vec![json!({
+                        "id": "call_status",
+                        "type": "function",
+                        "function": {
+                            "name": "foo-bar",
                             "arguments": "{}"
                         }
                     })]),
@@ -636,11 +736,8 @@ mod tests {
         };
 
         let (resp, _) = from_chat_response("resp_1".into(), "test-model", chat);
-        assert_eq!(resp.output.len(), 1);
-        assert_eq!(resp.output[0]["type"], "function_call");
-        assert_eq!(resp.output[0]["namespace"], "mcp__node_repl");
-        assert_eq!(resp.output[0]["name"], "status");
-        assert_eq!(resp.output[0]["call_id"], "call_status");
+        assert!(resp.output[0].get("namespace").is_none());
+        assert_eq!(resp.output[0]["name"], "foo-bar");
     }
 
     #[test]
@@ -669,6 +766,34 @@ mod tests {
         let (resp, _) = from_chat_response("resp_1".into(), "test-model", chat);
         assert!(resp.output[0].get("namespace").is_none());
         assert_eq!(resp.output[0]["name"], "mcp__node_repljs");
+    }
+
+    #[test]
+    fn test_from_chat_response_keeps_legacy_dot_namespace_split() {
+        let chat = ChatResponse {
+            choices: vec![ChatChoice {
+                message: ChatMessage {
+                    role: "assistant".into(),
+                    content: None,
+                    reasoning_content: None,
+                    tool_calls: Some(vec![json!({
+                        "id": "call_status",
+                        "type": "function",
+                        "function": {
+                            "name": "mcp__node_repl.status",
+                            "arguments": "{}"
+                        }
+                    })]),
+                    tool_call_id: None,
+                    name: None,
+                },
+            }],
+            usage: None,
+        };
+
+        let (resp, _) = from_chat_response("resp_1".into(), "test-model", chat);
+        assert_eq!(resp.output[0]["namespace"], "mcp__node_repl");
+        assert_eq!(resp.output[0]["name"], "status");
     }
 
     #[test]
@@ -739,7 +864,7 @@ mod tests {
                 ]
             }),
         ];
-        let denied = HashSet::from(["spawn_agent".to_string(), "mcp__server.blocked".to_string()]);
+        let denied = HashSet::from(["spawn_agent".to_string(), "mcp__server-blocked".to_string()]);
 
         let converted = convert_tools_with_denylist(&tools, &denied);
         let names: Vec<&str> = converted
@@ -751,7 +876,7 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(names, ["exec_command", "mcp__server.allowed"]);
+        assert_eq!(names, ["exec_command", "mcp__server-allowed"]);
     }
 
     #[test]

--- a/tests/compat_codex_0_128.rs
+++ b/tests/compat_codex_0_128.rs
@@ -57,8 +57,8 @@ fn namespace_tools_are_flattened() {
         names,
         vec![
             "exec_command",
-            "mcp__codex_apps__github._add_comment_to_issue",
-            "mcp__codex_apps__github._close_issue"
+            "mcp__codex_apps__github-_add_comment_to_issue",
+            "mcp__codex_apps__github-_close_issue"
         ]
     );
 

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -12,7 +12,9 @@ use axum::{
     Router,
 };
 use codex_relay::session::SessionStore;
-use codex_relay::translate::{from_chat_response, to_chat_request};
+use codex_relay::translate::{
+    from_chat_response_with_tool_map, namespace_tool_map, to_chat_request,
+};
 use codex_relay::types::{ChatChoice, ChatMessage, ChatResponse, ResponsesRequest};
 use eventsource_stream::Eventsource;
 use futures_util::StreamExt;
@@ -61,7 +63,7 @@ fn issue_6_namespace_tools_keep_namespace_when_flattened() {
     assert!(
         names
             .iter()
-            .any(|n| n == "mcp__codex_apps__github._add_comment_to_issue"),
+            .any(|n| n == "mcp__codex_apps__github-_add_comment_to_issue"),
         "namespace child tool should be flattened with its namespace prefix: {names:?}"
     );
 }
@@ -78,7 +80,7 @@ fn issue_17_blocking_namespaced_tool_calls_emit_namespace_field() {
                     "id": "call_js",
                     "type": "function",
                     "function": {
-                        "name": "mcp__node_repl.js",
+                        "name": "mcp__node_repl-js",
                         "arguments": "{}"
                     }
                 })]),
@@ -88,11 +90,50 @@ fn issue_17_blocking_namespaced_tool_calls_emit_namespace_field() {
         }],
         usage: None,
     };
+    let tools = vec![json!({
+        "type": "namespace",
+        "name": "mcp__node_repl",
+        "tools": [{"type": "function", "name": "js"}]
+    })];
+    let namespace_tools = namespace_tool_map(&tools);
 
-    let (resp, _) = from_chat_response("resp_17".into(), "mock-model", chat);
+    let (resp, _) =
+        from_chat_response_with_tool_map("resp_17".into(), "mock-model", chat, &namespace_tools);
     assert_eq!(resp.output[0]["type"], "function_call");
     assert_eq!(resp.output[0]["namespace"], "mcp__node_repl");
     assert_eq!(resp.output[0]["name"], "js");
+}
+
+#[test]
+fn issue_20_blocking_hyphen_flat_tool_name_is_not_namespaced() {
+    let chat = ChatResponse {
+        choices: vec![ChatChoice {
+            message: ChatMessage {
+                role: "assistant".into(),
+                content: None,
+                reasoning_content: None,
+                tool_calls: Some(vec![json!({
+                    "id": "call_flat",
+                    "type": "function",
+                    "function": {
+                        "name": "foo-bar",
+                        "arguments": "{}"
+                    }
+                })]),
+                tool_call_id: None,
+                name: None,
+            },
+        }],
+        usage: None,
+    };
+    let tools = vec![json!({"type": "function", "name": "foo-bar"})];
+    let namespace_tools = namespace_tool_map(&tools);
+
+    let (resp, _) =
+        from_chat_response_with_tool_map("resp_20".into(), "mock-model", chat, &namespace_tools);
+    assert_eq!(resp.output[0]["type"], "function_call");
+    assert!(resp.output[0].get("namespace").is_none());
+    assert_eq!(resp.output[0]["name"], "foo-bar");
 }
 
 #[derive(Clone)]
@@ -179,6 +220,14 @@ async fn spawn_mock_upstream_with_responses(
 }
 
 async fn post_stream_completed(relay: &Relay, body: Value) -> Value {
+    let events = post_stream_events(relay, body).await;
+    events
+        .into_iter()
+        .find_map(|(event, data)| (event == "response.completed").then_some(data))
+        .expect("response.completed event")
+}
+
+async fn post_stream_events(relay: &Relay, body: Value) -> Vec<(String, Value)> {
     let resp = reqwest::Client::new()
         .post(relay.url("/v1/responses"))
         .json(&body)
@@ -188,18 +237,23 @@ async fn post_stream_completed(relay: &Relay, body: Value) -> Value {
     assert!(resp.status().is_success(), "status {}", resp.status());
 
     let mut events = resp.bytes_stream().eventsource();
+    let mut out = Vec::new();
     let deadline = Instant::now() + Duration::from_secs(8);
     while let Some(ev) = tokio::time::timeout(deadline - Instant::now(), events.next())
         .await
         .expect("stream timeout")
     {
         let ev = ev.expect("sse parse");
-        if ev.event == "response.completed" {
-            return serde_json::from_str(&ev.data).expect("completed json");
+        let event = ev.event;
+        let data: Value = serde_json::from_str(&ev.data).expect("event json");
+        let terminal = event == "response.completed" || event == "response.failed";
+        out.push((event, data));
+        if terminal {
+            return out;
         }
     }
 
-    panic!("response.completed event");
+    panic!("terminal response event");
 }
 
 struct Relay {
@@ -308,7 +362,7 @@ async fn issue_17_streaming_namespaced_tool_calls_emit_namespace_field() {
                         "index": 0,
                         "id": "call_js",
                         "function": {
-                            "name": "mcp__node_repl.js",
+                            "name": "mcp__node_repl-js",
                             "arguments": "{}"
                         }
                     }]
@@ -320,7 +374,7 @@ async fn issue_17_streaming_namespaced_tool_calls_emit_namespace_field() {
     let (upstream_port, bodies) = spawn_mock_upstream_with_responses(vec![tool_sse]).await;
     let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
 
-    let completed = post_stream_completed(
+    let events = post_stream_events(
         &relay,
         json!({
             "model": "mock-model",
@@ -339,6 +393,30 @@ async fn issue_17_streaming_namespaced_tool_calls_emit_namespace_field() {
     )
     .await;
 
+    let added = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.added" && data["item"]["type"] == "function_call"
+        })
+        .map(|(_, data)| &data["item"])
+        .expect("function_call added item");
+    assert_eq!(added["namespace"], "mcp__node_repl");
+    assert_eq!(added["name"], "js");
+
+    let done = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.done" && data["item"]["type"] == "function_call"
+        })
+        .map(|(_, data)| &data["item"])
+        .expect("function_call done item");
+    assert_eq!(done["namespace"], "mcp__node_repl");
+    assert_eq!(done["name"], "js");
+
+    let completed = events
+        .iter()
+        .find_map(|(event, data)| (event == "response.completed").then_some(data))
+        .expect("response.completed");
     let item = &completed["response"]["output"][0];
     assert_eq!(item["type"], "function_call");
     assert_eq!(item["namespace"], "mcp__node_repl");
@@ -346,9 +424,75 @@ async fn issue_17_streaming_namespaced_tool_calls_emit_namespace_field() {
 
     let request_bodies = bodies.lock().unwrap();
     assert_eq!(
-        request_bodies[0]["tools"][0]["function"]["name"], "mcp__node_repl.js",
+        request_bodies[0]["tools"][0]["function"]["name"], "mcp__node_repl-js",
         "namespace tools must be flattened with a reversible separator"
     );
+}
+
+#[tokio::test]
+async fn issue_20_streaming_hyphen_flat_tool_name_is_not_namespaced() {
+    let tool_sse = sse_from_chunks(vec![
+        json!({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_flat",
+                        "function": {
+                            "name": "foo-bar",
+                            "arguments": "{}"
+                        }
+                    }]
+                }
+            }]
+        }),
+        json!({"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":3,"total_tokens":14}}),
+    ]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![tool_sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "input": "Use the flat tool.",
+            "tools": [{
+                "type": "function",
+                "name": "foo-bar",
+                "parameters": {"type": "object"}
+            }],
+            "stream": true
+        }),
+    )
+    .await;
+
+    let added = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.added" && data["item"]["type"] == "function_call"
+        })
+        .map(|(_, data)| &data["item"])
+        .expect("function_call added item");
+    assert!(added.get("namespace").is_none());
+    assert_eq!(added["name"], "foo-bar");
+
+    let done = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.done" && data["item"]["type"] == "function_call"
+        })
+        .map(|(_, data)| &data["item"])
+        .expect("function_call done item");
+    assert!(done.get("namespace").is_none());
+    assert_eq!(done["name"], "foo-bar");
+
+    let completed = events
+        .iter()
+        .find_map(|(event, data)| (event == "response.completed").then_some(data))
+        .expect("response.completed");
+    let item = &completed["response"]["output"][0];
+    assert!(item.get("namespace").is_none());
+    assert_eq!(item["name"], "foo-bar");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Implements the #20 direction: namespace tool decoding now uses a request-scoped map built from the original Responses `tools` array instead of relying on separator-only parsing.

## Root Cause

#18 restored namespace routing by introducing a reversible `namespace.child` flattened name, but `.` is outside the Chat Completions tool-name charset accepted by strict upstreams. #19 moved the separator to `-`, which is charset-legal, but decoding by `split_once('-')` can misclassify legitimate flat tools like `foo-bar`.

## Changes

- Build `flattened_chat_name -> { namespace, child_name }` from namespace tools in the current request.
- Use that map for blocking and streaming Chat Completions -> Responses tool-call translation.
- Keep legacy `.` and old `mcp__...__child` decoding as a fallback when no request map entry exists.
- Use `-` for forwarded namespace tool names so upstream tool names match `^[a-zA-Z0-9_-]+$`.
- Update denylist docs and debug-name expectations to the charset-legal flattened format.

## Regression Coverage

- #17/#18: namespace tool calls round-trip to Responses as `namespace` plus child `name`.
- #19: forwarded namespace tool names avoid `.` and use a charset-legal separator.
- #20: flat hyphenated tools like `foo-bar` remain flat and do not get a `namespace` field.
- Streaming: `response.output_item.added`, `response.output_item.done`, and `response.completed` all use the request-scoped map.

## Validation

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

Fixes #20.
Refs #17, #18, #19.
