### PR TITLE
feat: log prompt-cache hit/miss per request at debug level

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -336,6 +336,7 @@ pub fn translate_stream(
             }
             output_items.extend(fc_items);
             let usage = stream_usage.unwrap_or_default();
+            debug!("cache(stream): {}", usage.cache_summary());
 
             yield Ok(Event::default()
                 .event("response.completed")

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -429,6 +429,7 @@ pub fn from_chat_response_with_tool_map(
         });
 
     let usage = chat.usage.unwrap_or_default();
+    tracing::debug!("cache(non-stream): {}", usage.cache_summary());
     let mut output = Vec::new();
 
     let text = choice.message.text_content().to_string();

--- a/src/types.rs
+++ b/src/types.rs
@@ -217,3 +217,70 @@ pub struct DeltaFunction {
     #[serde(default)]
     pub arguments: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ChatUsage;
+    use serde_json::json;
+
+    #[test]
+    fn cache_summary_uses_deepseek_top_level_cache_fields() {
+        let usage: ChatUsage = serde_json::from_value(json!({
+            "prompt_tokens": 1203,
+            "completion_tokens": 25,
+            "total_tokens": 1228,
+            "prompt_cache_hit_tokens": 1152,
+            "prompt_cache_miss_tokens": 51
+        }))
+        .unwrap();
+
+        assert_eq!(
+            usage.cache_summary(),
+            "hit=1152 miss=51 prompt=1203 hit_rate=95.8%"
+        );
+    }
+
+    #[test]
+    fn cache_summary_uses_openai_prompt_tokens_details() {
+        let usage: ChatUsage = serde_json::from_value(json!({
+            "prompt_tokens": 893,
+            "completion_tokens": 12,
+            "total_tokens": 905,
+            "prompt_tokens_details": {
+                "cached_tokens": 640
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            usage.cache_summary(),
+            "hit=640 miss=253 prompt=893 hit_rate=71.7%"
+        );
+    }
+
+    #[test]
+    fn cache_summary_prefers_top_level_hit_when_both_shapes_exist() {
+        let usage: ChatUsage = serde_json::from_value(json!({
+            "prompt_tokens": 100,
+            "completion_tokens": 10,
+            "total_tokens": 110,
+            "prompt_cache_hit_tokens": 25,
+            "prompt_tokens_details": {
+                "cached_tokens": 90
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            usage.cache_summary(),
+            "hit=25 miss=75 prompt=100 hit_rate=25.0%"
+        );
+    }
+
+    #[test]
+    fn cache_summary_handles_missing_usage_fields() {
+        let usage = ChatUsage::default();
+
+        assert_eq!(usage.cache_summary(), "hit=0 miss=0 prompt=0 hit_rate=0.0%");
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -125,6 +125,53 @@ pub struct ChatUsage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+    // Prompt-cache accounting. Providers disagree on the shape:
+    //   DeepSeek / packyapi: top-level prompt_cache_{hit,miss}_tokens
+    //   OpenAI-compatible:   prompt_tokens_details.cached_tokens
+    // Capture both; normalize via cache_hit()/cache_miss().
+    #[serde(default)]
+    pub prompt_cache_hit_tokens: Option<u32>,
+    #[serde(default)]
+    pub prompt_cache_miss_tokens: Option<u32>,
+    #[serde(default)]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct PromptTokensDetails {
+    #[serde(default)]
+    pub cached_tokens: u32,
+}
+
+impl ChatUsage {
+    /// Cached (hit) prompt tokens. Prefers the DeepSeek-style top-level field,
+    /// else falls back to the OpenAI-style `prompt_tokens_details.cached_tokens`.
+    fn cache_hit(&self) -> u32 {
+        self.prompt_cache_hit_tokens
+            .or_else(|| self.prompt_tokens_details.as_ref().map(|d| d.cached_tokens))
+            .unwrap_or(0)
+    }
+
+    /// Non-cached (miss) prompt tokens; falls back to `prompt_tokens - hit`.
+    fn cache_miss(&self) -> u32 {
+        self.prompt_cache_miss_tokens
+            .unwrap_or_else(|| self.prompt_tokens.saturating_sub(self.cache_hit()))
+    }
+
+    /// One-line prompt-cache summary for debug logging, e.g.
+    /// `hit=1152 miss=51 prompt=1203 hit_rate=95.8%`.
+    pub fn cache_summary(&self) -> String {
+        let (hit, prompt) = (self.cache_hit(), self.prompt_tokens);
+        let rate = if prompt > 0 {
+            100.0 * hit as f64 / prompt as f64
+        } else {
+            0.0
+        };
+        format!(
+            "hit={hit} miss={} prompt={prompt} hit_rate={rate:.1}%",
+            self.cache_miss()
+        )
+    }
 }
 
 // ── SSE streaming types ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Surface upstream **prompt-cache** accounting in the relay logs. For every request, at `RUST_LOG=codex_relay=debug`, the relay now emits a one-line summary on both the streaming and non-streaming paths:

```
cache(stream):     hit=1152 miss=51 prompt=1203 hit_rate=95.8%
cache(non-stream): hit=0    miss=893 prompt=893  hit_rate=0.0%
```

## Why

`ChatUsage` only deserialized `prompt_tokens` / `completion_tokens` / `total_tokens`, so the cache fields in the upstream `usage` object were silently dropped. Cache effectiveness was therefore invisible even with debug logging enabled — there was no way to confirm whether prefix caching was actually working through the relay.

## How

- Extend `ChatUsage` with the cache fields and normalize across the two shapes providers use:
  - DeepSeek-style top-level `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`
  - OpenAI-style `prompt_tokens_details.cached_tokens`
- Add `ChatUsage::cache_summary()` and log it once per request. `cache_miss()` falls back to `prompt_tokens - hit` when the provider only reports hits.

Debug-level only; no change to the translated response or to default (info) logging.

## Test

Verified end-to-end against a live OpenAI-compatible provider (DeepSeek `deepseek-v4`): sending an identical ~1.2k-token prompt twice produced `hit=0` on the cold request and a `~96%` hit rate on the warm one, matching the provider's own `usage` numbers. Confirmed the streaming final-usage chunk carries the cache fields too.