### PR TITLE
[codex] Fix V2 subagent child isolation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -601,13 +601,24 @@ fn should_isolate_spawn_child_request(req: &ResponsesRequest, history: &[ChatMes
         .iter()
         .filter_map(|msg| msg.tool_call_id.as_deref())
         .collect();
-    history.iter().any(|msg| {
-        msg.tool_calls.as_deref().unwrap_or(&[]).iter().any(|call| {
+    let pending_spawns = history
+        .iter()
+        .flat_map(|msg| msg.tool_calls.as_deref().unwrap_or(&[]))
+        .filter(|call| {
             let call_id = call.get("id").and_then(serde_json::Value::as_str);
             call_id.is_none_or(|id| !completed_tool_calls.contains(id))
-                && spawn_agent_message(call).is_some_and(|message| message == input_text)
         })
-    })
+        .filter_map(parse_spawn_agent_call)
+        .collect::<Vec<_>>();
+
+    if pending_spawns
+        .iter()
+        .any(|spawn| spawn.message.as_deref() == Some(input_text))
+    {
+        return true;
+    }
+
+    pending_spawns.len() == 1 && pending_spawns[0].is_v2_encrypted_candidate()
 }
 
 fn isolated_user_text(input: &ResponsesInput) -> Option<&str> {
@@ -634,7 +645,22 @@ fn isolated_user_text(input: &ResponsesInput) -> Option<&str> {
     }
 }
 
-fn spawn_agent_message(call: &serde_json::Value) -> Option<String> {
+struct SpawnAgentCall {
+    message: Option<String>,
+    fork_turns: Option<String>,
+}
+
+impl SpawnAgentCall {
+    fn is_v2_encrypted_candidate(&self) -> bool {
+        self.fork_turns.is_some()
+            && self
+                .message
+                .as_deref()
+                .is_some_and(|message| !message.is_empty())
+    }
+}
+
+fn parse_spawn_agent_call(call: &serde_json::Value) -> Option<SpawnAgentCall> {
     if call
         .get("function")
         .and_then(|function| function.get("name"))
@@ -648,10 +674,16 @@ fn spawn_agent_message(call: &serde_json::Value) -> Option<String> {
         .and_then(|function| function.get("arguments"))
         .and_then(serde_json::Value::as_str)?;
     let arguments: serde_json::Value = serde_json::from_str(arguments).ok()?;
-    arguments
-        .get("message")
-        .and_then(serde_json::Value::as_str)
-        .map(String::from)
+    Some(SpawnAgentCall {
+        message: arguments
+            .get("message")
+            .and_then(serde_json::Value::as_str)
+            .map(String::from),
+        fork_turns: arguments
+            .get("fork_turns")
+            .and_then(serde_json::Value::as_str)
+            .map(String::from),
+    })
 }
 
 async fn handle_blocking(
@@ -864,6 +896,80 @@ mod tests {
         }];
 
         assert!(should_isolate_spawn_child_request(&req, &history));
+    }
+
+    #[test]
+    fn test_spawn_child_request_isolated_for_single_v2_encrypted_spawn() {
+        let req = ResponsesRequest {
+            model: "test".into(),
+            input: ResponsesInput::Text("child task decrypted by codex".into()),
+            previous_response_id: Some("resp_parent".into()),
+            tools: vec![],
+            stream: false,
+            temperature: None,
+            max_output_tokens: None,
+            system: None,
+            instructions: None,
+        };
+        let history = vec![ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            reasoning_content: None,
+            tool_calls: Some(vec![json!({
+                "id": "call_spawn",
+                "type": "function",
+                "function": {
+                    "name": "spawn_agent",
+                    "arguments": "{\"task_name\":\"child\",\"fork_turns\":\"current_turn\",\"message\":\"encrypted:v2:ciphertext\"}"
+                }
+            })]),
+            tool_call_id: None,
+            name: None,
+        }];
+
+        assert!(should_isolate_spawn_child_request(&req, &history));
+    }
+
+    #[test]
+    fn test_spawn_child_v2_encrypted_fallback_requires_unambiguous_spawn() {
+        let req = ResponsesRequest {
+            model: "test".into(),
+            input: ResponsesInput::Text("child task decrypted by codex".into()),
+            previous_response_id: Some("resp_parent".into()),
+            tools: vec![],
+            stream: false,
+            temperature: None,
+            max_output_tokens: None,
+            system: None,
+            instructions: None,
+        };
+        let history = vec![ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            reasoning_content: None,
+            tool_calls: Some(vec![
+                json!({
+                    "id": "call_spawn_a",
+                    "type": "function",
+                    "function": {
+                        "name": "spawn_agent",
+                        "arguments": "{\"task_name\":\"a\",\"fork_turns\":\"current_turn\",\"message\":\"encrypted:v2:a\"}"
+                    }
+                }),
+                json!({
+                    "id": "call_spawn_b",
+                    "type": "function",
+                    "function": {
+                        "name": "spawn_agent",
+                        "arguments": "{\"task_name\":\"b\",\"fork_turns\":\"current_turn\",\"message\":\"encrypted:v2:b\"}"
+                    }
+                }),
+            ]),
+            tool_call_id: None,
+            name: None,
+        }];
+
+        assert!(!should_isolate_spawn_child_request(&req, &history));
     }
 
     #[test]

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -679,3 +679,106 @@ async fn issue_12_spawn_agent_child_context_should_not_replay_parent_history() {
         "child upstream request should contain exactly the spawned message as user input"
     );
 }
+
+#[tokio::test]
+async fn issue_24_v2_encrypted_spawn_child_context_is_isolated() {
+    let child_task = "Inspect the repository and report the risky files.";
+    let parent_prompt = "Ask a subagent to inspect the repository.";
+    let tool_args = json!({
+        "task_name": "repo_inspection",
+        "fork_turns": "current_turn",
+        "message": "encrypted:v2:opaque-child-task-ciphertext",
+    })
+    .to_string();
+    let spawn_agent_sse = sse_from_chunks(vec![
+        json!({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_spawn_repo_inspection",
+                        "function": {
+                            "name": "spawn_agent",
+                            "arguments": tool_args
+                        }
+                    }]
+                }
+            }]
+        }),
+        json!({"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":3,"total_tokens":14}}),
+    ]);
+
+    let (upstream_port, bodies) =
+        spawn_mock_upstream_with_responses(vec![spawn_agent_sse, default_ok_sse()]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let parent_completed = post_stream_completed(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "instructions": "You are the parent agent.",
+            "input": parent_prompt,
+            "tools": [
+                {"type": "function", "name": "spawn_agent"},
+                {"type": "function", "name": "wait_agent"}
+            ],
+            "stream": true
+        }),
+    )
+    .await;
+    let parent_response_id = parent_completed["response"]["id"]
+        .as_str()
+        .expect("parent response id");
+
+    let _child_completed = post_stream_completed(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "instructions": "You are the spawned child agent.",
+            "previous_response_id": parent_response_id,
+            "input": child_task,
+            "tools": [
+                {"type": "function", "name": "spawn_agent"},
+                {"type": "function", "name": "wait_agent"},
+                {"type": "function", "name": "list_agents"},
+                {"type": "function", "name": "interrupt_agent"},
+                {"type": "function", "name": "send_message"},
+                {"type": "function", "name": "followup_task"}
+            ],
+            "stream": true
+        }),
+    )
+    .await;
+
+    let request_bodies = bodies.lock().unwrap();
+    assert_eq!(request_bodies.len(), 2, "parent and child upstream calls");
+    let child_messages = request_bodies[1]["messages"]
+        .as_array()
+        .expect("child upstream messages");
+
+    assert!(
+        !child_messages
+            .iter()
+            .any(|msg| msg["content"] == parent_prompt),
+        "V2 encrypted child request leaked the parent prompt: {child_messages:#?}"
+    );
+    assert!(
+        !child_messages.iter().any(|msg| {
+            msg["tool_calls"].as_array().is_some_and(|calls| {
+                calls
+                    .iter()
+                    .any(|call| call["function"]["name"] == "spawn_agent")
+            })
+        }),
+        "V2 encrypted child request replayed the parent's spawn_agent call: {child_messages:#?}"
+    );
+    assert_eq!(
+        child_messages
+            .iter()
+            .filter(|msg| msg["role"] == "user")
+            .map(|msg| msg["content"].as_str().unwrap_or(""))
+            .collect::<Vec<_>>(),
+        vec![child_task],
+        "V2 encrypted child request should contain exactly the spawned message as user input"
+    );
+}


### PR DESCRIPTION
## Summary

This PR addresses the child-context isolation failure reported in #24 for Codex multi-agent V2 spawn calls.

- Keeps the existing V1 behavior: isolate a spawned child request when the child input matches the plaintext `spawn_agent.message`.
- Adds V2-aware fallback isolation for the unambiguous case where exactly one pending `spawn_agent` call has `fork_turns` and an opaque/encrypted `message`.
- Avoids guessing when there are multiple pending encrypted V2 spawns.
- Adds unit and local mock-relay regression coverage for the V2 encrypted-message shape.

## Root Cause

The relay previously matched child requests by comparing the next user input to the prior `spawn_agent` tool call's plaintext `message`. In Codex >= 0.141 V2 multi-agent tools, `message` is encrypted/opaque, so the comparison fails and the relay replays parent history into the child upstream request.

## Validation

- `cargo fmt --check`
- `cargo test test_spawn_child --bin codex-relay`
- `cargo test issue_24_v2_encrypted_spawn_child_context_is_isolated --test regression_issues`
- `cargo test`
- `git diff --check`

@JasonC93 could you test this branch/PR against your Codex >= 0.141 `multi_agent_version: v2` setup and confirm whether complex subagents stop stalling?

Release note: please do not publish a release after merging this PR; this should be merged only for source validation first.