### PR TITLE
[codex] support reasoning stream events

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Any OpenAI-compatible endpoint works.
 - **Streaming** — full SSE streaming with correct event sequencing
 - **Tool calls** — accumulates streaming deltas and emits structured function_call items
 - **Parallel tool calls** — consecutive function_call input items merged into one assistant message
-- **Reasoning models** — preserves `reasoning_content` across turns (Kimi k2.6, DeepSeek-R1)
+- **Reasoning models** — streams `reasoning_content` as Responses reasoning summaries and preserves it across turns (Kimi k2.6, DeepSeek-R1)
 - **Model catalog** — proxies `/v1/models` from the upstream provider
 - **Auto-config** — `--print-config` generates a complete Codex config with model metadata
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -73,6 +73,7 @@ pub fn translate_stream(
         model,
     } = args;
     let msg_item_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
+    let reasoning_item_id = format!("rs_{}", uuid::Uuid::new_v4().simple());
 
     let event_stream = stream! {
         yield Ok(Event::default()
@@ -110,7 +111,9 @@ pub fn translate_stream(
         let mut accumulated_text = String::new();
         let mut accumulated_reasoning = String::new();
         let mut tool_calls: BTreeMap<usize, ToolCallAccum> = BTreeMap::new();
-        let mut emitted_message_item = false;
+        let mut reasoning_output_index: Option<usize> = None;
+        let mut message_output_index: Option<usize> = None;
+        let mut next_output_index: usize = 0;
         let mut stream_done = false;
         let mut stream_usage: Option<ChatUsage> = None;
         let mut source = upstream.bytes_stream().eventsource();
@@ -138,36 +141,71 @@ pub fn translate_stream(
                                 // Reasoning/thinking content (kimi-k2.6 etc.)
                                 if let Some(rc) = choice.delta.reasoning_content.as_deref() {
                                     if !rc.is_empty() {
+                                        let output_index = match reasoning_output_index {
+                                            Some(idx) => idx,
+                                            None => {
+                                                let idx = next_output_index;
+                                                next_output_index += 1;
+                                                reasoning_output_index = Some(idx);
+                                                yield Ok(Event::default()
+                                                    .event("response.output_item.added")
+                                                    .data(json!({
+                                                        "type": "response.output_item.added",
+                                                        "output_index": idx,
+                                                        "item": {
+                                                            "type": "reasoning",
+                                                            "id": &reasoning_item_id,
+                                                            "summary": [{"type": "summary_text", "text": ""}]
+                                                        }
+                                                    }).to_string()));
+                                                idx
+                                            }
+                                        };
                                         accumulated_reasoning.push_str(rc);
+                                        yield Ok(Event::default()
+                                            .event("response.reasoning_summary_text.delta")
+                                            .data(json!({
+                                                "type": "response.reasoning_summary_text.delta",
+                                                "item_id": &reasoning_item_id,
+                                                "output_index": output_index,
+                                                "summary_index": 0,
+                                                "delta": rc
+                                            }).to_string()));
                                     }
                                 }
 
                                 // Text content
                                 let content = choice.delta.content.as_deref().unwrap_or("");
                                 if !content.is_empty() {
-                                    if !emitted_message_item {
-                                        yield Ok(Event::default()
-                                            .event("response.output_item.added")
-                                            .data(json!({
-                                                "type": "response.output_item.added",
-                                                "output_index": 0,
-                                                "item": {
-                                                    "type": "message",
-                                                    "id": &msg_item_id,
-                                                    "role": "assistant",
-                                                    "status": "in_progress",
-                                                    "content": []
-                                                }
-                                            }).to_string()));
-                                        emitted_message_item = true;
-                                    }
+                                    let output_index = match message_output_index {
+                                        Some(idx) => idx,
+                                        None => {
+                                            let idx = next_output_index;
+                                            next_output_index += 1;
+                                            message_output_index = Some(idx);
+                                            yield Ok(Event::default()
+                                                .event("response.output_item.added")
+                                                .data(json!({
+                                                    "type": "response.output_item.added",
+                                                    "output_index": idx,
+                                                    "item": {
+                                                        "type": "message",
+                                                        "id": &msg_item_id,
+                                                        "role": "assistant",
+                                                        "status": "in_progress",
+                                                        "content": []
+                                                    }
+                                                }).to_string()));
+                                            idx
+                                        }
+                                    };
                                     accumulated_text.push_str(content);
                                     yield Ok(Event::default()
                                         .event("response.output_text.delta")
                                         .data(json!({
                                             "type": "response.output_text.delta",
                                             "item_id": &msg_item_id,
-                                            "output_index": 0,
+                                            "output_index": output_index,
                                             "delta": content
                                         }).to_string()));
                                 }
@@ -204,12 +242,26 @@ pub fn translate_stream(
             }
         }
 
-        if let Some(msg_item_id) = (emitted_message_item).then(|| msg_item_id.clone()) {
+        if let Some(output_index) = reasoning_output_index {
             yield Ok(Event::default()
                 .event("response.output_item.done")
                 .data(json!({
                     "type": "response.output_item.done",
-                    "output_index": 0,
+                    "output_index": output_index,
+                    "item": {
+                        "type": "reasoning",
+                        "id": &reasoning_item_id,
+                        "summary": [{"type": "summary_text", "text": &accumulated_reasoning}]
+                    }
+                }).to_string()));
+        }
+
+        if let Some(output_index) = message_output_index {
+            yield Ok(Event::default()
+                .event("response.output_item.done")
+                .data(json!({
+                    "type": "response.output_item.done",
+                    "output_index": output_index,
                     "item": {
                         "type": "message",
                         "id": &msg_item_id,
@@ -221,8 +273,8 @@ pub fn translate_stream(
         }
 
         // Emit function_call items for each accumulated tool call
-        let base_index: usize = if emitted_message_item { 1 } else { 0 };
-        let mut fc_items: Vec<Value> = Vec::new();
+        let base_index = next_output_index;
+        let mut fc_items: Vec<(usize, Value)> = Vec::new();
         debug!(
             "← upstream stream function_calls={}",
             summarize_stream_tool_call_names(&tool_calls)
@@ -280,7 +332,7 @@ pub fn translate_stream(
                     "item": done_item
                 }).to_string()));
 
-            fc_items.push(done_item);
+            fc_items.push((output_index, done_item));
         }
 
         if stream_done {
@@ -324,17 +376,29 @@ pub fn translate_stream(
             sessions.save_with_id(response_id.clone(), messages);
 
             // Build output array for response.completed
-            let mut output_items: Vec<Value> = Vec::new();
-            if emitted_message_item {
-                output_items.push(json!({
+            let mut indexed_output_items: Vec<(usize, Value)> = Vec::new();
+            if let Some(output_index) = reasoning_output_index {
+                indexed_output_items.push((output_index, json!({
+                    "type": "reasoning",
+                    "id": &reasoning_item_id,
+                    "summary": [{"type": "summary_text", "text": &accumulated_reasoning}]
+                })));
+            }
+            if let Some(output_index) = message_output_index {
+                indexed_output_items.push((output_index, json!({
                     "type": "message",
                     "id": &msg_item_id,
                     "role": "assistant",
                     "status": "completed",
                     "content": [{"type": "output_text", "text": &accumulated_text}]
-                }));
+                })));
             }
-            output_items.extend(fc_items);
+            indexed_output_items.extend(fc_items);
+            indexed_output_items.sort_by_key(|(idx, _)| *idx);
+            let output_items: Vec<Value> = indexed_output_items
+                .into_iter()
+                .map(|(_, item)| item)
+                .collect();
             let usage = stream_usage.unwrap_or_default();
             debug!("cache(stream): {}", usage.cache_summary());
 

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -434,6 +434,93 @@ async fn streaming_response_usage_includes_cached_tokens() {
 }
 
 #[tokio::test]
+async fn issue_26_streaming_reasoning_content_emits_responses_reasoning_events() {
+    let reasoning_sse = sse_from_chunks(vec![
+        json!({"choices":[{"delta":{"role":"assistant","reasoning_content":"think "}}]}),
+        json!({"choices":[{"delta":{"reasoning_content":"through it"}}]}),
+        json!({"choices":[{"delta":{"content":"OK"}}]}),
+        json!({"choices":[],"usage":{"prompt_tokens":9,"completion_tokens":3,"total_tokens":12}}),
+    ]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![reasoning_sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "input": "Reason briefly.",
+            "tools": [],
+            "stream": true
+        }),
+    )
+    .await;
+
+    let reasoning_added = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.added" && data["item"]["type"] == "reasoning"
+        })
+        .map(|(_, data)| data)
+        .expect("reasoning output_item.added");
+    assert_eq!(reasoning_added["output_index"], 0);
+    let reasoning_item_id = reasoning_added["item"]["id"]
+        .as_str()
+        .expect("reasoning item id");
+
+    let deltas: Vec<&Value> = events
+        .iter()
+        .filter_map(|(event, data)| {
+            (event == "response.reasoning_summary_text.delta").then_some(data)
+        })
+        .collect();
+    assert_eq!(deltas.len(), 2);
+    assert_eq!(deltas[0]["delta"], "think ");
+    assert_eq!(deltas[1]["delta"], "through it");
+    for delta in deltas {
+        assert_eq!(delta["item_id"], reasoning_item_id);
+        assert_eq!(delta["output_index"], 0);
+        assert_eq!(delta["summary_index"], 0);
+    }
+
+    let reasoning_done = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.done" && data["item"]["type"] == "reasoning"
+        })
+        .map(|(_, data)| data)
+        .expect("reasoning output_item.done");
+    assert_eq!(reasoning_done["output_index"], 0);
+    assert_eq!(
+        reasoning_done["item"]["summary"],
+        json!([{"type": "summary_text", "text": "think through it"}])
+    );
+
+    let message_added = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.added" && data["item"]["type"] == "message"
+        })
+        .map(|(_, data)| data)
+        .expect("message output_item.added");
+    assert_eq!(message_added["output_index"], 1);
+
+    let completed = events
+        .iter()
+        .find_map(|(event, data)| (event == "response.completed").then_some(data))
+        .expect("response.completed");
+    assert_eq!(completed["response"]["output"][0]["type"], "reasoning");
+    assert_eq!(
+        completed["response"]["output"][0]["summary"],
+        json!([{"type": "summary_text", "text": "think through it"}])
+    );
+    assert_eq!(completed["response"]["output"][1]["type"], "message");
+    assert_eq!(
+        completed["response"]["output"][1]["content"],
+        json!([{"type": "output_text", "text": "OK"}])
+    );
+}
+
+#[tokio::test]
 async fn issue_17_streaming_namespaced_tool_calls_emit_namespace_field() {
     let tool_sse = sse_from_chunks(vec![
         json!({


### PR DESCRIPTION
## Summary

Adds Responses streaming events for Chat Completions `delta.reasoning_content` so reasoning-capable OpenAI-compatible providers can surface reasoning in Codex instead of dropping it.

## Root Cause

The relay already accumulated and stored upstream `reasoning_content` for cross-turn replay, but the streaming translation path only emitted assistant text and tool-call Responses events. Reasoning deltas were silently retained internally without being exposed to the Responses SSE client.

## Changes

- Emit a Responses `reasoning` output item when upstream streaming chunks include `delta.reasoning_content`.
- Map reasoning chunks to `response.reasoning_summary_text.delta` with `summary_index` metadata expected by Codex CLI.
- Include the completed reasoning summary item in `response.output_item.done` and `response.completed` output.
- Add a local mock-upstream regression test for issue #26.
- Update README feature text to mention streamed reasoning summaries.

## Validation

- `cargo fmt -- --check`
- `cargo test --test regression_issues issue_26_streaming_reasoning_content_emits_responses_reasoning_events`
- `cargo test`

Closes #26.