### PR TITLE
fix(reasoning): enable GLM thinking so issue #26 works in practice

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -110,6 +110,7 @@ pub fn translate_stream(
 
         let mut accumulated_text = String::new();
         let mut accumulated_reasoning = String::new();
+        let mut reasoning_chunks: usize = 0;
         let mut tool_calls: BTreeMap<usize, ToolCallAccum> = BTreeMap::new();
         let mut reasoning_output_index: Option<usize> = None;
         let mut message_output_index: Option<usize> = None;
@@ -138,9 +139,12 @@ pub fn translate_stream(
                                 stream_usage = usage;
                             }
                             for choice in &choices {
-                                // Reasoning/thinking content (kimi-k2.6 etc.)
-                                if let Some(rc) = choice.delta.reasoning_content.as_deref() {
+                                // Reasoning/thinking content (kimi-k2.6, GLM, etc.).
+                                // Field name varies by provider (reasoning_content
+                                // vs reasoning) — normalized via reasoning_text().
+                                if let Some(rc) = choice.delta.reasoning_text() {
                                     if !rc.is_empty() {
+                                        reasoning_chunks += 1;
                                         let output_index = match reasoning_output_index {
                                             Some(idx) => idx,
                                             None => {
@@ -278,6 +282,13 @@ pub fn translate_stream(
         debug!(
             "← upstream stream function_calls={}",
             summarize_stream_tool_call_names(&tool_calls)
+        );
+        // Counts only (never the reasoning text) so issue #26 can be diagnosed:
+        // distinguishes "upstream sent no reasoning" from "received but not translated".
+        debug!(
+            "← upstream stream reasoning chunks={} bytes={}",
+            reasoning_chunks,
+            accumulated_reasoning.len()
         );
 
         for (rel_idx, (_, tc)) in tool_calls.iter().enumerate() {

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -204,8 +204,17 @@ pub fn to_chat_request(
         }
     }
 
+    let mapped_model = map_model_name(&req.model);
+    // GLM/Zhipu only emits reasoning_content when `thinking` is explicitly
+    // enabled; its default auto-thinking is suppressed by heavy agent system
+    // prompts (e.g. Codex). Other providers (DeepSeek/Kimi) think by default and
+    // must not receive this field, so it stays GLM-gated to preserve their
+    // request shape. See GitHub issue #26.
+    let enable_glm_thinking =
+        is_glm_like_model(&req.model) || is_glm_like_model(&mapped_model);
+
     ChatRequest {
-        model: map_model_name(&req.model),
+        model: mapped_model,
         messages,
         tools: convert_tools(&req.tools),
         temperature: req.temperature,
@@ -213,8 +222,18 @@ pub fn to_chat_request(
         stream_options: req.stream.then_some(ChatStreamOptions {
             include_usage: true,
         }),
+        thinking: enable_glm_thinking.then(|| ChatThinking {
+            kind: "enabled".into(),
+        }),
         stream: req.stream,
     }
+}
+
+/// Whether a model name looks like a GLM/Zhipu reasoning model that needs the
+/// explicit `thinking` switch to emit reasoning_content.
+fn is_glm_like_model(model: &str) -> bool {
+    let m = model.to_ascii_lowercase();
+    m.contains("glm") || m.contains("zhipu") || m.contains("bigmodel")
 }
 
 /// Map model names via `CODEX_RELAY_MODEL_MAP` env var.

--- a/src/types.rs
+++ b/src/types.rs
@@ -78,12 +78,24 @@ pub struct ChatRequest {
     pub max_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_options: Option<ChatStreamOptions>,
+    /// Zhipu/GLM thinking switch. Only serialized for GLM-like models so other
+    /// providers keep their existing request shape. GLM suppresses its default
+    /// auto-thinking under heavy agent system prompts (e.g. Codex), so this must
+    /// be sent explicitly for reasoning to be emitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ChatThinking>,
     pub stream: bool,
 }
 
 #[derive(Debug, Serialize)]
 pub struct ChatStreamOptions {
     pub include_usage: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChatThinking {
+    #[serde(rename = "type")]
+    pub kind: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -202,10 +214,26 @@ pub struct ChatDelta {
     #[allow(dead_code)]
     pub role: Option<String>,
     pub content: Option<String>,
+    /// Thinking content. Providers disagree on the field name: DeepSeek/Kimi/GLM
+    /// use `reasoning_content`; OpenRouter/Together-style (and some newer GLM-5
+    /// deployments) use `reasoning`. Capture both and normalize via
+    /// [`ChatDelta::reasoning_text`].
     #[serde(default)]
     pub reasoning_content: Option<String>,
     #[serde(default)]
+    pub reasoning: Option<String>,
+    #[serde(default)]
     pub tool_calls: Option<Vec<DeltaToolCall>>,
+}
+
+impl ChatDelta {
+    /// Normalized reasoning delta, preferring `reasoning_content` and falling
+    /// back to the `reasoning` alias.
+    pub fn reasoning_text(&self) -> Option<&str> {
+        self.reasoning_content
+            .as_deref()
+            .or(self.reasoning.as_deref())
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -434,6 +434,88 @@ async fn streaming_response_usage_includes_cached_tokens() {
 }
 
 #[tokio::test]
+async fn issue_26_glm_model_enables_thinking_on_upstream_request() {
+    // GLM suppresses default auto-thinking under heavy agent prompts, so the
+    // relay must send `thinking:{type:"enabled"}` for GLM-like models — otherwise
+    // no reasoning_content is ever produced and there is nothing to translate.
+    let (upstream_port, bodies) = spawn_mock_upstream().await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let _ = post_stream_completed(
+        &relay,
+        json!({"model": "glm-5.2", "input": "hi", "tools": [], "stream": true}),
+    )
+    .await;
+
+    let body = bodies.lock().unwrap().last().cloned().expect("upstream body");
+    assert_eq!(
+        body["thinking"],
+        json!({"type": "enabled"}),
+        "GLM request must enable thinking"
+    );
+}
+
+#[tokio::test]
+async fn issue_26_non_glm_model_does_not_send_thinking() {
+    // DeepSeek/Kimi/etc. think by default and may reject unknown fields, so the
+    // request shape for non-GLM models must be unchanged.
+    let (upstream_port, bodies) = spawn_mock_upstream().await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let _ = post_stream_completed(
+        &relay,
+        json!({"model": "deepseek-reasoner", "input": "hi", "tools": [], "stream": true}),
+    )
+    .await;
+
+    let body = bodies.lock().unwrap().last().cloned().expect("upstream body");
+    assert!(
+        body.get("thinking").is_none(),
+        "non-GLM request must not include thinking: {body}"
+    );
+}
+
+#[tokio::test]
+async fn issue_26_streaming_reasoning_alias_field_emits_reasoning_events() {
+    // Some providers (OpenRouter/Together-style, newer GLM-5 deployments) stream
+    // thinking under `delta.reasoning` rather than `delta.reasoning_content`.
+    let reasoning_sse = sse_from_chunks(vec![
+        json!({"choices":[{"delta":{"role":"assistant","reasoning":"alias "}}]}),
+        json!({"choices":[{"delta":{"reasoning":"path"}}]}),
+        json!({"choices":[{"delta":{"content":"OK"}}]}),
+        json!({"choices":[],"usage":{"prompt_tokens":9,"completion_tokens":3,"total_tokens":12}}),
+    ]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![reasoning_sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({"model": "mock-model", "input": "Reason briefly.", "tools": [], "stream": true}),
+    )
+    .await;
+
+    let deltas: Vec<&Value> = events
+        .iter()
+        .filter_map(|(event, data)| {
+            (event == "response.reasoning_summary_text.delta").then_some(data)
+        })
+        .collect();
+    assert_eq!(deltas.len(), 2);
+    assert_eq!(deltas[0]["delta"], "alias ");
+    assert_eq!(deltas[1]["delta"], "path");
+
+    let completed = events
+        .iter()
+        .find_map(|(event, data)| (event == "response.completed").then_some(data))
+        .expect("response.completed");
+    assert_eq!(completed["response"]["output"][0]["type"], "reasoning");
+    assert_eq!(
+        completed["response"]["output"][0]["summary"],
+        json!([{"type": "summary_text", "text": "alias path"}])
+    );
+}
+
+#[tokio::test]
 async fn issue_26_streaming_reasoning_content_emits_responses_reasoning_events() {
     let reasoning_sse = sse_from_chunks(vec![
         json!({"choices":[{"delta":{"role":"assistant","reasoning_content":"think "}}]}),


### PR DESCRIPTION
## Summary

Issue #26 was only half-fixed in v0.3.5. The streaming **output** translation (`delta.reasoning_content` → `response.reasoning_summary_text.delta`) is correct — I reproduced it against GLM's exact real wire shape (null sibling fields, `usage:null` per chunk, `index`/`logprobs`/`matched_stop`) and it emits reasoning events fine.

The real gap is on the **request** side: the relay built the Chat Completions request without any thinking flag, so GLM never produced `reasoning_content` and there was nothing to translate.

GLM/Zhipu only emits `reasoning_content` when the request carries `thinking: {"type": "enabled"}`. Its default auto-thinking is suppressed by heavy agent system prompts (e.g. Codex). Confirmed by two independent projects:

- NousResearch/hermes-agent#16533 — "Without `thinking` set, GLM-5.1/4.6/4.5 produce regular completions with no `reasoning_content` deltas."
- claude-code-router blog — Codex/Claude Code's heavy system prompt disrupts GLM's internal reasoning judgment, so it rarely thinks.

The reporter's interceptor saw `reasoning_content` only through their **own** proxy (which injected thinking); the direct curl to the relay got none — because the relay requested none.

## Changes

- **types** — add `ChatRequest.thinking` (`thinking:{type:"enabled"}`, gated by `skip_serializing_if` so absent for everyone else); add a `reasoning` alias on `ChatDelta` with `reasoning_text()` (GLM-5 / OpenRouter / Together stream thinking under `reasoning`, not `reasoning_content`).
- **translate** — send `thinking` **only for GLM-like models** (`glm`/`zhipu`/`bigmodel`, checked on both requested and mapped name) so DeepSeek/Kimi/OpenRouter request shapes are unchanged.
- **stream** — normalize via `reasoning_text()`; add a content-free debug log (`reasoning chunks=N bytes=M`) to distinguish "upstream sent no reasoning" from "received but not translated" without leaking chain-of-thought.
- **tests** — GLM enables thinking, non-GLM does not, and `delta.reasoning` alias emits reasoning events.

## Verification

- `cargo test` — full suite green (14 regression tests incl. 3 new issue_26 tests)
- `cargo clippy -- -D warnings` — clean

## Note / follow-up

GLM detection is name-based. If a user routes GLM under a non-GLM alias via `CODEX_RELAY_MODEL_MAP`, the gate may miss it; the new debug log (`RUST_LOG=codex_relay=debug` → `reasoning chunks=0`) makes that diagnosable. A `CODEX_RELAY_THINKING=auto|on|off` override could be added as a fallback if needed.

Refs #26
