### PR TITLE
[codex] add upstream request parameter overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ input_modalities = ["text"]
 | `--port` | `CODEX_RELAY_PORT` | `4444` | Listen port |
 | `--upstream` | `CODEX_RELAY_UPSTREAM` | `https://openrouter.ai/api/v1` | Upstream Chat Completions base URL |
 | `--api-key` | `CODEX_RELAY_API_KEY` | _(empty)_ | API key forwarded to upstream |
+| `--upstream-extra-params` | `CODEX_RELAY_UPSTREAM_EXTRA_PARAMS` | _(empty)_ | JSON object merged into each upstream Chat Completions request |
+| `--drop-upstream-params` | `CODEX_RELAY_DROP_PARAMS` | _(empty)_ | JSON array of top-level upstream request parameters to remove |
 | `--model-map` | `CODEX_RELAY_MODEL_MAP` | _(empty)_ | Comma-separated `source:target` model name translations |
 | `--print-config` | _(none)_ | — | Print a Codex config snippet with `model_properties` and exit |
 | `--session-ttl-hours` | `CODEX_RELAY_SESSION_TTL_HOURS` | `168` | Retain idle `previous_response_id` history and reasoning state for this many hours |
@@ -102,6 +104,19 @@ input_modalities = ["text"]
 
 Any OpenAI-compatible endpoint works.
 
+### Upstream request parameters
+
+Some providers expose non-standard Chat Completions parameters. You can merge
+top-level JSON fields into every upstream request, and optionally drop generated
+top-level fields before the merge. For example, to disable DeepSeek V4
+thinking/reasoning mode:
+
+```bash
+CODEX_RELAY_UPSTREAM_EXTRA_PARAMS='{"thinking":{"type":"disabled"}}' \
+CODEX_RELAY_DROP_PARAMS='["reasoning_effort"]' \
+codex-relay --upstream https://api.deepseek.com/v1 --api-key "$DEEPSEEK_API_KEY"
+```
+
 ## Features
 
 - **Streaming** — full SSE streaming with correct event sequencing
@@ -118,6 +133,8 @@ Any OpenAI-compatible endpoint works.
 | `CODEX_RELAY_PORT` | `4444` | Port to listen on |
 | `CODEX_RELAY_UPSTREAM` | `https://openrouter.ai/api/v1` | Upstream Chat Completions base URL |
 | `CODEX_RELAY_API_KEY` | _(empty)_ | API key forwarded to upstream |
+| `CODEX_RELAY_UPSTREAM_EXTRA_PARAMS` | _(empty)_ | JSON object merged into each upstream Chat Completions request body |
+| `CODEX_RELAY_DROP_PARAMS` | _(empty)_ | JSON array of top-level upstream request parameter names to remove before forwarding |
 | `CODEX_RELAY_MODEL_MAP` | _(empty)_ | Comma-separated `source:target` model name translations (e.g., `gpt-5.4:deepseek-v4-pro`) |
 | `CODEX_RELAY_TOOL_DENYLIST` | _(empty)_ | Comma-separated tool names to remove before forwarding tools to the upstream model |
 | `CODEX_RELAY_SESSION_TTL_HOURS` | `168` | Retain idle session/reasoning state for this many hours |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod session;
 pub mod stream;
 pub mod translate;
 pub mod types;
+pub mod upstream_request;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod session;
 mod stream;
 mod translate;
 mod types;
+mod upstream_request;
 
 use anyhow::{bail, Result};
 use axum::{
@@ -17,6 +18,7 @@ use session::{SessionStore, DEFAULT_MAX_SESSIONS, DEFAULT_MAX_SESSION_BYTES, DEF
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use tracing::{debug, error, info, warn};
 use types::*;
+use upstream_request::UpstreamRequestConfig;
 
 const DEBUG_NAME_LIMIT: usize = 80;
 
@@ -38,6 +40,14 @@ struct Args {
 
     #[arg(long, env = "CODEX_RELAY_API_KEY", default_value = "")]
     api_key: String,
+
+    /// JSON object merged into every upstream Chat Completions request body.
+    #[arg(long, env = "CODEX_RELAY_UPSTREAM_EXTRA_PARAMS")]
+    upstream_extra_params: Option<String>,
+
+    /// JSON array of top-level upstream request parameter names to remove.
+    #[arg(long, env = "CODEX_RELAY_DROP_PARAMS")]
+    drop_upstream_params: Option<String>,
 
     /// Print a ready-to-use Codex config.toml snippet (including model_properties)
     /// for all models exposed by the upstream provider.
@@ -87,6 +97,7 @@ struct AppState {
     client: Client,
     upstream: Arc<Url>,
     api_key: Arc<String>,
+    upstream_request: Arc<UpstreamRequestConfig>,
 }
 
 #[tokio::main]
@@ -101,6 +112,10 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     let upstream = validate_upstream(&args.upstream)?;
+    let upstream_request = Arc::new(UpstreamRequestConfig::from_raw(
+        args.upstream_extra_params.as_deref(),
+        args.drop_upstream_params.as_deref(),
+    )?);
 
     let client = Client::new();
     let api_key = Arc::new(args.api_key);
@@ -144,6 +159,7 @@ async fn main() -> Result<()> {
         client: client.clone(),
         upstream: Arc::new(upstream.clone()),
         api_key: api_key.clone(),
+        upstream_request: upstream_request.clone(),
     };
     info!(
         "session retention: store={} dir={} ttl={}h max_sessions={} max_session_memory={} MiB",
@@ -153,6 +169,13 @@ async fn main() -> Result<()> {
         args.max_sessions,
         args.max_session_memory_mb
     );
+    if !upstream_request.is_empty() {
+        info!(
+            "upstream request params: extra={} drop={}",
+            upstream_request.extra_param_count(),
+            upstream_request.drop_param_count()
+        );
+    }
 
     // Fetch upstream model list asynchronously for user visibility
     tokio::spawn(log_upstream_models(client, Arc::new(upstream), api_key));
@@ -580,6 +603,7 @@ async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Respo
             url,
             api_key: state.api_key,
             chat_req,
+            upstream_request: state.upstream_request,
             response_id,
             sessions: state.sessions,
             request_messages,
@@ -702,7 +726,15 @@ async fn handle_blocking(
         builder = builder.bearer_auth(state.api_key.as_str());
     }
 
-    match builder.json(&chat_req).send().await {
+    let upstream_body = match state.upstream_request.request_body(&chat_req) {
+        Ok(body) => body,
+        Err(e) => {
+            error!("upstream request body error: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+
+    match builder.json(&upstream_body).send().await {
         Err(e) => {
             error!("upstream error: {e}");
             (StatusCode::BAD_GATEWAY, e.to_string()).into_response()

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -14,6 +14,7 @@ use crate::{
     session::SessionStore,
     translate::{response_function_name_for_responses, NamespaceToolMap},
     types::{ChatMessage, ChatRequest, ChatStreamChunk, ChatUsage},
+    upstream_request::UpstreamRequestConfig,
 };
 
 pub struct StreamArgs {
@@ -21,6 +22,7 @@ pub struct StreamArgs {
     pub url: String,
     pub api_key: Arc<String>,
     pub chat_req: ChatRequest,
+    pub upstream_request: Arc<UpstreamRequestConfig>,
     pub response_id: String,
     pub sessions: SessionStore,
     /// The fully translated request messages (including replayed history).
@@ -66,6 +68,7 @@ pub fn translate_stream(
         url,
         api_key,
         chat_req,
+        upstream_request,
         response_id,
         sessions,
         request_messages,
@@ -88,7 +91,18 @@ pub fn translate_stream(
             builder = builder.bearer_auth(api_key.as_str());
         }
 
-        let upstream = match builder.json(&chat_req).send().await {
+        let upstream_body = match upstream_request.request_body(&chat_req) {
+            Ok(body) => body,
+            Err(e) => {
+                error!("upstream request body error: {e}");
+                yield Ok(Event::default().event("response.failed").data(
+                    json!({"type": "response.failed", "response": {"id": &response_id, "status": "failed", "error": {"code": "request_body_error", "message": e.to_string()}}}).to_string()
+                ));
+                return;
+            }
+        };
+
+        let upstream = match builder.json(&upstream_body).send().await {
             Ok(r) if r.status().is_success() => r,
             Ok(r) => {
                 let status = r.status();

--- a/src/upstream_request.rs
+++ b/src/upstream_request.rs
@@ -1,0 +1,127 @@
+use anyhow::{bail, Context, Result};
+use serde_json::{Map, Value};
+
+use crate::types::ChatRequest;
+
+#[derive(Clone, Debug, Default)]
+pub struct UpstreamRequestConfig {
+    extra_params: Map<String, Value>,
+    drop_params: Vec<String>,
+}
+
+impl UpstreamRequestConfig {
+    pub fn from_raw(extra_params: Option<&str>, drop_params: Option<&str>) -> Result<Self> {
+        Ok(Self {
+            extra_params: parse_extra_params(extra_params)?,
+            drop_params: parse_drop_params(drop_params)?,
+        })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.extra_params.is_empty() && self.drop_params.is_empty()
+    }
+
+    pub fn extra_param_count(&self) -> usize {
+        self.extra_params.len()
+    }
+
+    pub fn drop_param_count(&self) -> usize {
+        self.drop_params.len()
+    }
+
+    pub fn request_body(&self, chat_req: &ChatRequest) -> Result<Value> {
+        let mut body = serde_json::to_value(chat_req)?;
+        let object = body
+            .as_object_mut()
+            .context("serialized chat request was not a JSON object")?;
+
+        for key in &self.drop_params {
+            object.remove(key);
+        }
+        for (key, value) in &self.extra_params {
+            object.insert(key.clone(), value.clone());
+        }
+
+        Ok(body)
+    }
+}
+
+fn parse_extra_params(raw: Option<&str>) -> Result<Map<String, Value>> {
+    let Some(raw) = non_empty(raw) else {
+        return Ok(Map::new());
+    };
+    match serde_json::from_str::<Value>(raw)? {
+        Value::Object(object) => Ok(object),
+        _ => bail!("--upstream-extra-params must be a JSON object"),
+    }
+}
+
+fn parse_drop_params(raw: Option<&str>) -> Result<Vec<String>> {
+    let Some(raw) = non_empty(raw) else {
+        return Ok(Vec::new());
+    };
+    let values = serde_json::from_str::<Vec<String>>(raw)
+        .context("--drop-upstream-params must be a JSON array of strings")?;
+    if values.iter().any(|value| value.is_empty()) {
+        bail!("--drop-upstream-params entries must not be empty");
+    }
+    Ok(values)
+}
+
+fn non_empty(raw: Option<&str>) -> Option<&str> {
+    raw.map(str::trim).filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::types::ChatMessage;
+
+    fn chat_request() -> ChatRequest {
+        ChatRequest {
+            model: "deepseek-v4-pro".into(),
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: Some(json!("hello")),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
+            }],
+            tools: Vec::new(),
+            temperature: Some(0.2),
+            max_tokens: Some(100),
+            stream_options: None,
+            thinking: None,
+            stream: false,
+        }
+    }
+
+    #[test]
+    fn merges_extra_params_and_drops_top_level_params() {
+        let config = UpstreamRequestConfig::from_raw(
+            Some(r#"{"thinking":{"type":"disabled"},"temperature":0.7}"#),
+            Some(r#"["max_tokens"]"#),
+        )
+        .unwrap();
+
+        let body = config.request_body(&chat_request()).unwrap();
+
+        assert_eq!(body["thinking"], json!({"type": "disabled"}));
+        assert_eq!(body["temperature"], json!(0.7));
+        assert!(body.get("max_tokens").is_none());
+        assert_eq!(body["model"], json!("deepseek-v4-pro"));
+    }
+
+    #[test]
+    fn rejects_non_object_extra_params() {
+        assert!(UpstreamRequestConfig::from_raw(Some(r#"["thinking"]"#), None).is_err());
+    }
+
+    #[test]
+    fn rejects_non_string_drop_params() {
+        assert!(UpstreamRequestConfig::from_raw(None, Some(r#"["ok", 1]"#)).is_err());
+    }
+}

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -311,16 +311,23 @@ impl Drop for Relay {
 
 impl Relay {
     fn spawn(upstream: &str) -> Self {
+        Self::spawn_with_env(upstream, &[])
+    }
+
+    fn spawn_with_env(upstream: &str, extra_env: &[(&str, &str)]) -> Self {
         let port = pick_port();
-        let child = Command::new(RELAY_BIN)
+        let mut command = Command::new(RELAY_BIN);
+        command
             .env("CODEX_RELAY_PORT", port.to_string())
             .env("CODEX_RELAY_UPSTREAM", upstream)
             .env("CODEX_RELAY_API_KEY", "")
             .env("RUST_LOG", "codex_relay=warn")
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("spawn codex-relay");
+            .stderr(Stdio::null());
+        for (key, value) in extra_env {
+            command.env(key, value);
+        }
+        let child = command.spawn().expect("spawn codex-relay");
 
         let mut handle = Relay { child, port };
         handle.wait_ready();
@@ -341,6 +348,36 @@ impl Relay {
     fn url(&self, path: &str) -> String {
         format!("http://127.0.0.1:{}{}", self.port, path)
     }
+}
+
+#[tokio::test]
+async fn issue_29_extra_and_drop_params_modify_streaming_upstream_request() {
+    let (upstream_port, bodies) = spawn_mock_upstream().await;
+    let relay = Relay::spawn_with_env(
+        &format!("http://127.0.0.1:{upstream_port}/v1"),
+        &[
+            (
+                "CODEX_RELAY_UPSTREAM_EXTRA_PARAMS",
+                r#"{"thinking":{"type":"disabled"}}"#,
+            ),
+            ("CODEX_RELAY_DROP_PARAMS", r#"["stream_options"]"#),
+        ],
+    );
+
+    let _ = post_stream_completed(
+        &relay,
+        json!({"model": "glm-5.2", "input": "hi", "tools": [], "stream": true}),
+    )
+    .await;
+
+    let body = bodies
+        .lock()
+        .unwrap()
+        .last()
+        .cloned()
+        .expect("upstream body");
+    assert_eq!(body["thinking"], json!({"type": "disabled"}));
+    assert!(body.get("stream_options").is_none(), "body: {body}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Adds upstream request parameter overrides for providers that require non-standard Chat Completions fields.

## Changes

- Adds `--upstream-extra-params` / `CODEX_RELAY_UPSTREAM_EXTRA_PARAMS` to merge a JSON object into every upstream request body.
- Adds `--drop-upstream-params` / `CODEX_RELAY_DROP_PARAMS` to remove generated top-level fields before forwarding.
- Applies the same transformation to blocking and streaming upstream requests.
- Documents the DeepSeek V4 `thinking: {type: "disabled"}` use case.

## Why

DeepSeek V4 can enable thinking/reasoning by default, and disabling it requires upstream-specific request fields. Some of those fields can conflict with generated request parameters, so the relay needs both injection and removal hooks.

Closes #29.

## Validation

- `cargo fmt`
- `cargo test`
