### PR TITLE
Complete turns without [DONE] (#31) and fix parallel test port races (#32)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -194,12 +194,14 @@ async fn main() -> Result<()> {
         .with_state(state.clone());
 
     let addr = format!("127.0.0.1:{}", args.port);
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    // Log the actual bound address so that `--port 0` (ephemeral port) reports
+    // the real port instead of `:0`.
     info!(
-        "codex-relay listening on {addr} → {}",
+        "codex-relay listening on {} → {}",
+        listener.local_addr()?,
         state.upstream.as_ref()
     );
-
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
     axum::serve(listener, app).await?;
 
     Ok(())

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -130,6 +130,7 @@ pub fn translate_stream(
         let mut message_output_index: Option<usize> = None;
         let mut next_output_index: usize = 0;
         let mut stream_done = false;
+        let mut stream_err = false;
         let mut stream_usage: Option<ChatUsage> = None;
         let mut source = upstream.bytes_stream().eventsource();
 
@@ -137,6 +138,7 @@ pub fn translate_stream(
             match ev {
                 Err(e) => {
                     warn!("SSE parse error: {e}");
+                    stream_err = true;
                     break;
                 }
                 Ok(ev) if ev.data.trim() == "[DONE]" => {
@@ -358,6 +360,17 @@ pub fn translate_stream(
                 }).to_string()));
 
             fc_items.push((output_index, done_item));
+        }
+
+        // Some OpenAI-compatible providers (e.g. synthetic.new) close the SSE
+        // stream cleanly without emitting a terminating `[DONE]` line. If the
+        // stream ended without an error and we already received a full turn
+        // (text and/or tool calls), treat it as complete so the response is
+        // persisted and `response.completed` is emitted. A mid-stream error
+        // (stream_err) still discards the partial turn.
+        if !stream_done && !stream_err && (!accumulated_text.is_empty() || !tool_calls.is_empty()) {
+            warn!("stream ended without [DONE] but content was received — treating as complete");
+            stream_done = true;
         }
 
         if stream_done {

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -20,7 +20,6 @@ use eventsource_stream::Eventsource;
 use futures_util::StreamExt;
 use serde_json::{json, Value};
 use std::collections::VecDeque;
-use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
@@ -34,13 +33,6 @@ fn fixture(name: &str) -> ResponsesRequest {
     p.push(name);
     let bytes = std::fs::read(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
     serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", p.display()))
-}
-
-fn pick_port() -> u16 {
-    let l = TcpListener::bind("127.0.0.1:0").expect("bind");
-    let p = l.local_addr().unwrap().port();
-    drop(l);
-    p
 }
 
 #[test]
@@ -225,6 +217,16 @@ fn sse_from_chunks(chunks: Vec<Value>) -> String {
     sse
 }
 
+fn sse_from_chunks_without_done(chunks: Vec<Value>) -> String {
+    let mut sse = String::new();
+    for chunk in chunks {
+        sse.push_str("data: ");
+        sse.push_str(&chunk.to_string());
+        sse.push_str("\n\n");
+    }
+    sse
+}
+
 fn default_ok_sse() -> String {
     sse_from_chunks(vec![
         json!({"choices":[{"delta":{"role":"assistant","content":"OK"}}]}),
@@ -239,7 +241,6 @@ async fn spawn_mock_upstream() -> (u16, Arc<Mutex<Vec<Value>>>) {
 async fn spawn_mock_upstream_with_responses(
     responses: Vec<String>,
 ) -> (u16, Arc<Mutex<Vec<Value>>>) {
-    let port = pick_port();
     let bodies = Arc::new(Mutex::new(Vec::new()));
     let state = MockState {
         bodies: bodies.clone(),
@@ -249,9 +250,12 @@ async fn spawn_mock_upstream_with_responses(
         .route("/v1/models", get(models_handler))
         .route("/v1/chat/completions", post(chat_handler))
         .with_state(state);
-    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+    // Bind to port 0 and keep the listener so the OS-assigned port cannot be
+    // grabbed by a concurrently running test (avoids a bind/drop/rebind race).
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
         .await
         .expect("bind mock upstream");
+    let port = listener.local_addr().expect("mock upstream addr").port();
     tokio::spawn(async move {
         axum::serve(listener, app)
             .await
@@ -315,23 +319,64 @@ impl Relay {
     }
 
     fn spawn_with_env(upstream: &str, extra_env: &[(&str, &str)]) -> Self {
-        let port = pick_port();
         let mut command = Command::new(RELAY_BIN);
         command
-            .env("CODEX_RELAY_PORT", port.to_string())
+            // Bind an ephemeral port; the real port is read from the child's
+            // startup log. This avoids a bind/drop/rebind race where two
+            // concurrent tests could pick the same port.
+            .env("CODEX_RELAY_PORT", "0")
             .env("CODEX_RELAY_UPSTREAM", upstream)
             .env("CODEX_RELAY_API_KEY", "")
-            .env("RUST_LOG", "codex_relay=warn")
-            .stdout(Stdio::null())
+            .env("RUST_LOG", "codex_relay=info")
+            .stdout(Stdio::piped())
             .stderr(Stdio::null());
         for (key, value) in extra_env {
             command.env(key, value);
         }
-        let child = command.spawn().expect("spawn codex-relay");
+        let mut child = command.spawn().expect("spawn codex-relay");
 
+        let port = Self::read_listening_port(&mut child);
         let mut handle = Relay { child, port };
         handle.wait_ready();
         handle
+    }
+
+    /// Read the bound port from the relay's `listening on 127.0.0.1:PORT` log line.
+    ///
+    /// A background thread keeps draining stdout for the child's lifetime so the
+    /// pipe never fills (which would block the relay) and stays open (closing it
+    /// would kill the relay with SIGPIPE on its next log write).
+    fn read_listening_port(child: &mut Child) -> u16 {
+        use std::io::{BufRead, BufReader};
+        use std::sync::mpsc;
+        let stdout = child.stdout.take().expect("relay stdout");
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            let mut line = String::new();
+            let mut tx = Some(tx);
+            loop {
+                line.clear();
+                match reader.read_line(&mut line) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {}
+                }
+                if let Some(sender) = tx.as_ref() {
+                    if let Some(rest) = line.split("listening on 127.0.0.1:").nth(1) {
+                        if let Some(port) = rest
+                            .split(|c: char| !c.is_ascii_digit())
+                            .next()
+                            .and_then(|s| s.parse::<u16>().ok())
+                        {
+                            let _ = sender.send(port);
+                            tx = None;
+                        }
+                    }
+                }
+            }
+        });
+        rx.recv_timeout(Duration::from_secs(8))
+            .expect("relay did not report a listening port")
     }
 
     fn wait_ready(&mut self) {
@@ -519,6 +564,37 @@ async fn issue_26_non_glm_model_does_not_send_thinking() {
     assert!(
         body.get("thinking").is_none(),
         "non-GLM request must not include thinking: {body}"
+    );
+}
+
+#[tokio::test]
+async fn issue_31_stream_without_done_still_completes_when_content_received() {
+    // Some OpenAI-compatible providers (e.g. synthetic.new) close the SSE stream
+    // cleanly without ever sending a terminating `[DONE]` line. A turn that
+    // received content should still complete rather than be discarded.
+    let no_done_sse = sse_from_chunks_without_done(vec![
+        json!({"choices":[{"delta":{"role":"assistant","content":"Hello"}}]}),
+        json!({"choices":[{"delta":{"content":" world"}}]}),
+        json!({"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}),
+    ]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![no_done_sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({"model": "mock-model", "input": "Say hi.", "tools": [], "stream": true}),
+    )
+    .await;
+
+    let completed = events
+        .iter()
+        .find_map(|(event, data)| (event == "response.completed").then_some(data));
+    let failed = events.iter().any(|(event, _)| event == "response.failed");
+    assert!(!failed, "stream should not fail when content was received");
+    let completed = completed.expect("response.completed");
+    assert_eq!(
+        completed["response"]["output"][0]["content"][0]["text"],
+        "Hello world"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes two recently reported issues.

### #31 — stream disconnects with synthetic.new

Some OpenAI-compatible providers (e.g. [synthetic.new](https://dev.synthetic.new/docs/api/overview)) close the SSE stream cleanly **without ever sending a terminating `[DONE]` line**. The relay treated this as a partial turn and discarded it, emitting `response.failed` with `stream_incomplete` even though the full response had been received.

We now track whether the stream ended via an error vs. a clean EOF:
- **Clean end** with accumulated text and/or tool calls → treat the turn as complete, persist it, and emit `response.completed`.
- **Mid-stream error** (`stream_err`) → still discard the partial turn (unchanged), avoiding the assistant-with-tool_calls history gap that causes upstream "insufficient tool messages" errors.

This matches the workaround proposed in #31.

### #32 — tests can break when run in parallel

`pick_port()` used a bind → drop → rebind pattern with a TOCTOU race, so two concurrent tests could grab the same port (the `issue_26_*` collision reported in #32, plus a latent race on the relay's own port).

- The **mock upstream** now binds port `0` and keeps the listener, reading the real port from `local_addr()`.
- The **relay subprocess** is launched with `CODEX_RELAY_PORT=0`; its actual port is parsed from the startup log. `src/main.rs` now binds first and logs the real `local_addr` (also fixing the misleading `:0` log when running with `--port 0`).
- A background thread drains the child's stdout so the pipe never fills (blocking the relay) or closes (SIGPIPE-killing it).
- Removed the now-unused `pick_port()` helper.

## Testing

- Added regression test `issue_31_stream_without_done_still_completes_when_content_received`.
- `cargo test --test regression_issues -- --test-threads=16` run 10× in a row: all green (previously flaky).
- Full `cargo test` suite passes.

Fixes #31
Fixes #32
