### PR TITLE
Add --version flag to CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,8 @@ const DEBUG_NAME_LIMIT: usize = 80;
 #[derive(Parser, Debug)]
 #[command(
     name = "codex-relay",
-    about = "Responses API ↔ Chat Completions bridge"
+    about = "Responses API ↔ Chat Completions bridge",
+    version = env!("CARGO_PKG_VERSION")
 )]
 struct Args {
     #[arg(long, env = "CODEX_RELAY_PORT", default_value = "4444")]


### PR DESCRIPTION
Add `--version` / `-V` flag to the CLI using `env!("CARGO_PKG_VERSION")` at compile time, reading the version from `Cargo.toml`.

  Before: `codex-relay --version` errored with "unexpected argument '--version' found"
  After: `codex-relay 0.4.1`