### PR TITLE
feat: add --bind flag to bind listener to any IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ input_modalities = ["text"]
 | Flag | Env var | Default | Description |
 |---|---|---|---|
 | `--port` | `CODEX_RELAY_PORT` | `4444` | Listen port |
+| `--bind` | `CODEX_RELAY_BIND` | `127.0.0.1` | IP address to bind the listener to (e.g. `0.0.0.0` to accept remote connections) |
 | `--upstream` | `CODEX_RELAY_UPSTREAM` | `https://openrouter.ai/api/v1` | Upstream Chat Completions base URL |
 | `--api-key` | `CODEX_RELAY_API_KEY` | _(empty)_ | API key forwarded to upstream |
 | `--upstream-extra-params` | `CODEX_RELAY_UPSTREAM_EXTRA_PARAMS` | _(empty)_ | JSON object merged into each upstream Chat Completions request |
@@ -131,6 +132,7 @@ codex-relay --upstream https://api.deepseek.com/v1 --api-key "$DEEPSEEK_API_KEY"
 | Variable | Default | Description |
 |---|---|---|
 | `CODEX_RELAY_PORT` | `4444` | Port to listen on |
+| `CODEX_RELAY_BIND` | `127.0.0.1` | IP address to bind the listener to (e.g. `0.0.0.0` to accept remote connections) |
 | `CODEX_RELAY_UPSTREAM` | `https://openrouter.ai/api/v1` | Upstream Chat Completions base URL |
 | `CODEX_RELAY_API_KEY` | _(empty)_ | API key forwarded to upstream |
 | `CODEX_RELAY_UPSTREAM_EXTRA_PARAMS` | _(empty)_ | JSON object merged into each upstream Chat Completions request body |

--- a/codex_relay/__init__.py
+++ b/codex_relay/__init__.py
@@ -29,6 +29,7 @@ def start(
     port: int = 4444,
     upstream: str = "https://openrouter.ai/api/v1",
     api_key: str = "",
+    bind: str = "127.0.0.1",
 ) -> subprocess.Popen:
     """Start codex-relay as a background process and return the Popen handle."""
     env = os.environ.copy()
@@ -36,7 +37,15 @@ def start(
         env["CODEX_RELAY_API_KEY"] = api_key
 
     return subprocess.Popen(
-        [str(_find_binary()), "--port", str(port), "--upstream", upstream],
+        [
+            str(_find_binary()),
+            "--port",
+            str(port),
+            "--bind",
+            bind,
+            "--upstream",
+            upstream,
+        ],
         env=env,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,10 @@ struct Args {
     #[arg(long, env = "CODEX_RELAY_PORT", default_value = "4444")]
     port: u16,
 
+    /// IP address to bind the listener to (e.g. 0.0.0.0 to accept remote connections).
+    #[arg(long, env = "CODEX_RELAY_BIND", default_value = "127.0.0.1")]
+    bind: std::net::IpAddr,
+
     #[arg(
         long,
         env = "CODEX_RELAY_UPSTREAM",
@@ -186,7 +190,8 @@ async fn main() -> Result<()> {
     // Disable axum's default 2 MiB body cap: Codex CLI may send base64-encoded
     // image attachments that easily exceed it, and a framework-level 413 looks
     // like a transport-layer death to Codex and crashes the session (#2).
-    // The relay only binds 127.0.0.1, so DoS isn't a concern here.
+    // The relay binds 127.0.0.1 by default; --bind can expose it more widely,
+    // so be mindful of DoS when binding to a non-loopback address.
     let app = Router::new()
         .route("/v1/responses", post(handle_responses))
         .route("/v1/models", get(handle_models))
@@ -194,8 +199,8 @@ async fn main() -> Result<()> {
         .layer(DefaultBodyLimit::disable())
         .with_state(state.clone());
 
-    let addr = format!("127.0.0.1:{}", args.port);
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let addr = std::net::SocketAddr::new(args.bind, args.port);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
     // Log the actual bound address so that `--port 0` (ephemeral port) reports
     // the real port instead of `:0`.
     info!(


### PR DESCRIPTION
## What

Adds a `--bind` flag so the relay can listen on any address instead of being hardcoded to `127.0.0.1`.

- New `--bind` CLI arg (env `CODEX_RELAY_BIND`, default `127.0.0.1`), parsed as `IpAddr` so invalid values are rejected at startup.
- Listener now binds `SocketAddr::new(args.bind, args.port)` instead of a hardcoded `127.0.0.1:{port}`.
- Python `start()` helper gains a `bind` parameter for parity.
- Documented in the README CLI reference and configuration tables.

## Why

Allows running the relay on a LAN/remote host, e.g. `--bind 0.0.0.0`, so Codex on another machine can reach it.

## Notes

⚠️ Binding to a non-loopback address exposes the relay on the network. It disables the body size cap and forwards your upstream API key, so it should only be used on trusted networks. The DoS comment in `main.rs` was updated accordingly.

## Testing

- `cargo build` — clean (pre-existing dead_code warning only)
- `cargo test` — 16 passed
- Manual: `codex-relay --bind 0.0.0.0 --port 4899` logs `listening on 0.0.0.0:4899`