### PR TITLE
feat: opt-in conversation corpus recording (--record-corpus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ input_modalities = ["text"]
 | `--drop-upstream-params` | `CODEX_RELAY_DROP_PARAMS` | _(empty)_ | JSON array of top-level upstream request parameters to remove |
 | `--model-map` | `CODEX_RELAY_MODEL_MAP` | _(empty)_ | Comma-separated `source:target` model name translations |
 | `--print-config` | _(none)_ | — | Print a Codex config snippet with `model_properties` and exit |
+| `--record-corpus` | `CODEX_RELAY_RECORD_CORPUS` | _(off)_ | Append the conversation flow of every completed turn to daily JSONL files (OpenAI messages format) in this directory |
 | `--session-ttl-hours` | `CODEX_RELAY_SESSION_TTL_HOURS` | `168` | Retain idle `previous_response_id` history and reasoning state for this many hours |
 | `--max-sessions` | `CODEX_RELAY_MAX_SESSIONS` | `256` | Maximum completed response histories retained for continuation |
 | `--max-session-memory-mb` | `CODEX_RELAY_MAX_SESSION_MEMORY_MB` | `512` | Approximate memory budget for retained session/reasoning state |
@@ -144,6 +145,7 @@ codex-relay --upstream https://api.deepseek.com/v1 --api-key "$DEEPSEEK_API_KEY"
 | `CODEX_RELAY_MAX_SESSION_MEMORY_MB` | `512` | Approximate memory budget for retained session/reasoning state |
 | `CODEX_RELAY_HISTORY_STORE` | `memory` | Retained history backend: `memory` or `disk` |
 | `CODEX_RELAY_HISTORY_DIR` | `.codex-relay-history` | Directory for disk-backed history records |
+| `CODEX_RELAY_RECORD_CORPUS` | _(off)_ | Directory to append per-turn conversation records (OpenAI messages JSONL); off unless set |
 | `RUST_LOG` | `codex_relay=info` | Log verbosity |
 
 ## Python API
@@ -209,6 +211,58 @@ index for disk-backed entries and loads payloads on demand.
 Treat this directory as sensitive: records may contain prompts, tool outputs,
 and other conversation data. The same TTL/count/byte retention knobs apply to
 disk-backed records, and evicted entries are removed from disk.
+
+### Corpus recording
+
+For building datasets, `--record-corpus <dir>` continuously appends the
+conversation flow to daily-sharded JSONL files in **OpenAI messages format**:
+
+```bash
+codex-relay --record-corpus ./corpus \
+  --upstream https://api.deepseek.com/v1 --api-key "$DEEPSEEK_API_KEY"
+```
+
+This is **off by default** and is a separate subsystem from the retention cache
+above: the corpus is an **append-only archive** that is never evicted, whereas
+the session store is an evictable continuation cache.
+
+Each line is an *incremental turn event* — only the messages new to that turn
+are written, so the same conversation is reconstructed by concatenating the
+`messages` of every event that shares a `conversation_id`:
+
+```text
+corpus/
+  corpus-2026-04-04.jsonl
+```
+
+```json
+{
+  "conversation_id": "resp_abc…",
+  "response_id": "resp_def…",
+  "parent_response_id": "resp_abc…",
+  "timestamp_unix_ms": 1783447750503,
+  "model": "deepseek-chat",
+  "messages": [ { "role": "user", "content": "…" }, { "role": "assistant", "content": "…" } ]
+}
+```
+
+The `messages` payload uses the standard OpenAI schema and preserves
+`tool_calls`, `role: "tool"` outputs (`tool_call_id`), and assistant
+`reasoning_content` (a widely-used non-standard field that training frameworks
+ignore if unknown). The first event of a conversation includes the system
+prompt; subsequent events omit it. Isolated `spawn_agent` child requests start
+their own `conversation_id`.
+
+To fold the turn events back into whole-conversation OpenAI records:
+
+```bash
+jq -s 'group_by(.conversation_id)[]
+       | {messages: (map(.messages) | add)}' corpus/*.jsonl
+```
+
+> ⚠️ Records contain prompts, tool call **arguments**, and tool outputs — more
+> than the debug logs ever emit. Treat the directory as sensitive, especially
+> when combined with `--bind` on a non-loopback address.
 
 ### Subagent tool routing
 

--- a/codex_relay/__init__.py
+++ b/codex_relay/__init__.py
@@ -30,22 +30,27 @@ def start(
     upstream: str = "https://openrouter.ai/api/v1",
     api_key: str = "",
     bind: str = "127.0.0.1",
+    record_corpus: str = "",
 ) -> subprocess.Popen:
     """Start codex-relay as a background process and return the Popen handle."""
     env = os.environ.copy()
     if api_key:
         env["CODEX_RELAY_API_KEY"] = api_key
 
+    cmd = [
+        str(_find_binary()),
+        "--port",
+        str(port),
+        "--bind",
+        bind,
+        "--upstream",
+        upstream,
+    ]
+    if record_corpus:
+        cmd += ["--record-corpus", record_corpus]
+
     return subprocess.Popen(
-        [
-            str(_find_binary()),
-            "--port",
-            str(port),
-            "--bind",
-            bind,
-            "--upstream",
-            upstream,
-        ],
+        cmd,
         env=env,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,

--- a/src/corpus.rs
+++ b/src/corpus.rs
@@ -1,0 +1,329 @@
+//! Opt-in conversation corpus recorder.
+//!
+//! When enabled (via `--record-corpus <dir>`), the relay appends the
+//! conversation flow of each completed turn to a daily-sharded JSONL file in
+//! OpenAI messages format. Each line is an *incremental turn event*: only the
+//! messages new to that turn are written, so a full conversation is
+//! reconstructed downstream by concatenating the `messages` of every event
+//! sharing a `conversation_id`.
+//!
+//! This subsystem is deliberately independent of [`crate::session::SessionStore`]:
+//! the session store is an evictable *continuation cache*, whereas the corpus is
+//! an append-only *archive* that is never evicted.
+//!
+//! Records may contain prompts, tool call arguments, and tool outputs. Treat
+//! the output directory as sensitive. Recording is off unless explicitly
+//! enabled.
+
+use serde_json::json;
+use std::collections::{HashMap, VecDeque};
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::warn;
+
+use crate::types::ChatMessage;
+
+/// Upper bound on response_id chains tracked in memory for delta computation.
+/// If a chain is evicted and a later child request references it, that child
+/// simply starts a new conversation — acceptable fragmentation, never data loss.
+const DEFAULT_MAX_TRACKED_CHAINS: usize = 4096;
+
+#[derive(Clone)]
+pub struct CorpusRecorder {
+    inner: Arc<Mutex<CorpusState>>,
+}
+
+struct CorpusState {
+    dir: PathBuf,
+    max_tracked: usize,
+    chains: HashMap<String, ChainPos>,
+    order: VecDeque<String>,
+}
+
+#[derive(Clone)]
+struct ChainPos {
+    conversation_id: String,
+    message_count: usize,
+}
+
+impl CorpusRecorder {
+    /// Create a recorder that appends to `dir`, creating it if necessary.
+    pub fn new(dir: impl AsRef<Path>) -> io::Result<Self> {
+        let dir = dir.as_ref().to_path_buf();
+        fs::create_dir_all(&dir)?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(CorpusState {
+                dir,
+                max_tracked: DEFAULT_MAX_TRACKED_CHAINS,
+                chains: HashMap::new(),
+                order: VecDeque::new(),
+            })),
+        })
+    }
+
+    /// Record one completed turn.
+    ///
+    /// `messages` is the full conversation for the new `response_id` (replayed
+    /// history + this turn's new input + the assistant reply). Only the
+    /// incremental delta since the parent turn is persisted.
+    pub fn record_turn(
+        &self,
+        parent_response_id: Option<&str>,
+        response_id: &str,
+        model: &str,
+        messages: &[ChatMessage],
+    ) {
+        let mut state = self.inner.lock().expect("corpus mutex poisoned");
+        state.record(parent_response_id, response_id, model, messages);
+    }
+}
+
+impl CorpusState {
+    fn record(
+        &mut self,
+        parent: Option<&str>,
+        response_id: &str,
+        model: &str,
+        messages: &[ChatMessage],
+    ) {
+        let parent_pos = parent.and_then(|p| self.chains.get(p)).cloned();
+        let conversation_id = parent_pos
+            .as_ref()
+            .map(|p| p.conversation_id.clone())
+            .unwrap_or_else(|| response_id.to_string());
+        let prev_count = parent_pos.as_ref().map(|p| p.message_count).unwrap_or(0);
+        let start = prev_count.min(messages.len());
+        let delta = &messages[start..];
+
+        if !delta.is_empty() {
+            let record = json!({
+                "conversation_id": conversation_id,
+                "response_id": response_id,
+                "parent_response_id": parent,
+                "timestamp_unix_ms": now_unix_ms(),
+                "model": model,
+                "messages": delta,
+            });
+            if let Err(e) = self.append(&record) {
+                warn!("failed to append corpus turn for {response_id}: {e}");
+            }
+        }
+
+        self.remember(response_id, conversation_id, messages.len());
+    }
+
+    fn remember(&mut self, response_id: &str, conversation_id: String, message_count: usize) {
+        let existed = self
+            .chains
+            .insert(
+                response_id.to_string(),
+                ChainPos {
+                    conversation_id,
+                    message_count,
+                },
+            )
+            .is_some();
+        if existed {
+            self.order.retain(|id| id != response_id);
+        }
+        self.order.push_back(response_id.to_string());
+
+        while self.chains.len() > self.max_tracked {
+            match self.order.pop_front() {
+                Some(old) => {
+                    self.chains.remove(&old);
+                }
+                None => break,
+            }
+        }
+    }
+
+    fn append(&self, record: &serde_json::Value) -> io::Result<()> {
+        let path = self.dir.join(format!("corpus-{}.jsonl", today_utc_date()));
+        let mut line = serde_json::to_string(record).map_err(io::Error::other)?;
+        line.push('\n');
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        file.write_all(line.as_bytes())
+    }
+}
+
+fn now_unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+/// Current UTC date as `YYYY-MM-DD`, computed without pulling in a date crate.
+fn today_utc_date() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let (y, m, d) = civil_from_days((secs / 86_400) as i64);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+/// Convert a count of days since the Unix epoch into a `(year, month, day)`
+/// Gregorian date. Howard Hinnant's `civil_from_days` algorithm.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    (y + i64::from(m <= 2), m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use uuid::Uuid;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("codex-relay-corpus-{name}-{}", Uuid::new_v4().simple()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn msg(role: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            role: role.into(),
+            content: Some(Value::String(content.into())),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }
+    }
+
+    fn read_lines(dir: &Path) -> Vec<Value> {
+        let mut out = Vec::new();
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let text = fs::read_to_string(&path).unwrap();
+            for line in text.lines().filter(|l| !l.trim().is_empty()) {
+                out.push(serde_json::from_str(line).unwrap());
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn records_full_conversation_on_first_turn() {
+        let dir = temp_dir("first-turn");
+        let recorder = CorpusRecorder::new(&dir).unwrap();
+
+        let full = vec![
+            msg("system", "you are helpful"),
+            msg("user", "hi"),
+            msg("assistant", "hello"),
+        ];
+        recorder.record_turn(None, "resp_a", "test-model", &full);
+
+        let lines = read_lines(&dir);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["conversation_id"], "resp_a");
+        assert_eq!(lines[0]["response_id"], "resp_a");
+        assert!(lines[0]["parent_response_id"].is_null());
+        assert_eq!(lines[0]["model"], "test-model");
+        assert_eq!(lines[0]["messages"].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn records_only_delta_on_continued_turn() {
+        let dir = temp_dir("delta");
+        let recorder = CorpusRecorder::new(&dir).unwrap();
+
+        let turn1 = vec![
+            msg("system", "sys"),
+            msg("user", "q1"),
+            msg("assistant", "a1"),
+        ];
+        recorder.record_turn(None, "resp_1", "m", &turn1);
+
+        // Second turn replays turn1 as history and appends new input + reply.
+        let turn2 = vec![
+            msg("system", "sys"),
+            msg("user", "q1"),
+            msg("assistant", "a1"),
+            msg("user", "q2"),
+            msg("assistant", "a2"),
+        ];
+        recorder.record_turn(Some("resp_1"), "resp_2", "m", &turn2);
+
+        let lines = read_lines(&dir);
+        assert_eq!(lines.len(), 2);
+
+        // Both events share the conversation id (the chain root).
+        assert_eq!(lines[1]["conversation_id"], "resp_1");
+        assert_eq!(lines[1]["response_id"], "resp_2");
+        assert_eq!(lines[1]["parent_response_id"], "resp_1");
+
+        let delta = lines[1]["messages"].as_array().unwrap();
+        assert_eq!(delta.len(), 2, "only the new turn's messages are recorded");
+        assert_eq!(delta[0]["content"], "q2");
+        assert_eq!(delta[1]["content"], "a2");
+    }
+
+    #[test]
+    fn preserves_tool_calls_and_reasoning() {
+        let dir = temp_dir("tool-reasoning");
+        let recorder = CorpusRecorder::new(&dir).unwrap();
+
+        let mut assistant = msg("assistant", "");
+        assistant.reasoning_content = Some("let me think".into());
+        assistant.tool_calls = Some(vec![json!({
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "exec", "arguments": "{\"cmd\":\"ls\"}"}
+        })]);
+        let mut tool = msg("tool", "file.txt");
+        tool.tool_call_id = Some("call_1".into());
+
+        let full = vec![msg("user", "list files"), assistant, tool];
+        recorder.record_turn(None, "resp_t", "m", &full);
+
+        let lines = read_lines(&dir);
+        let messages = lines[0]["messages"].as_array().unwrap();
+        assert_eq!(messages[1]["reasoning_content"], "let me think");
+        assert_eq!(messages[1]["tool_calls"][0]["function"]["name"], "exec");
+        assert_eq!(messages[2]["tool_call_id"], "call_1");
+    }
+
+    #[test]
+    fn isolated_child_with_unknown_parent_starts_new_conversation() {
+        let dir = temp_dir("isolated");
+        let recorder = CorpusRecorder::new(&dir).unwrap();
+
+        // Parent id was never recorded (e.g. spawn-child isolation cleared history).
+        let full = vec![msg("user", "child task"), msg("assistant", "done")];
+        recorder.record_turn(Some("resp_unknown"), "resp_child", "m", &full);
+
+        let lines = read_lines(&dir);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(
+            lines[0]["conversation_id"], "resp_child",
+            "unknown parent => new conversation rooted at self"
+        );
+        assert_eq!(lines[0]["messages"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn civil_from_days_matches_known_dates() {
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+        assert_eq!(civil_from_days(19_723), (2024, 1, 1));
+        assert_eq!(civil_from_days(20_547), (2026, 4, 4));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod corpus;
 pub mod session;
 pub mod stream;
 pub mod translate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod corpus;
 mod session;
 mod stream;
 mod translate;
@@ -13,6 +14,7 @@ use axum::{
     Json, Router,
 };
 use clap::Parser;
+use corpus::CorpusRecorder;
 use reqwest::{Client, Url};
 use session::{SessionStore, DEFAULT_MAX_SESSIONS, DEFAULT_MAX_SESSION_BYTES, DEFAULT_SESSION_TTL};
 use std::{path::PathBuf, sync::Arc, time::Duration};
@@ -94,6 +96,13 @@ struct Args {
         default_value = ".codex-relay-history"
     )]
     history_dir: PathBuf,
+
+    /// Append the conversation flow of every completed turn to daily-sharded
+    /// JSONL files (OpenAI messages format) in this directory. Off by default.
+    /// Records contain prompts, tool call arguments, and tool outputs — treat
+    /// the directory as sensitive.
+    #[arg(long, env = "CODEX_RELAY_RECORD_CORPUS")]
+    record_corpus: Option<PathBuf>,
 }
 
 #[derive(Clone)]
@@ -103,6 +112,7 @@ struct AppState {
     upstream: Arc<Url>,
     api_key: Arc<String>,
     upstream_request: Arc<UpstreamRequestConfig>,
+    corpus: Option<CorpusRecorder>,
 }
 
 #[tokio::main]
@@ -159,12 +169,24 @@ async fn main() -> Result<()> {
         )?,
         other => bail!("history store must be 'memory' or 'disk', got: {other}"),
     };
+    let corpus = match &args.record_corpus {
+        Some(dir) => {
+            let recorder = CorpusRecorder::new(dir)?;
+            warn!(
+                "corpus recording ENABLED → {} (records prompts, tool arguments, and tool outputs; treat as sensitive)",
+                dir.display()
+            );
+            Some(recorder)
+        }
+        None => None,
+    };
     let state = AppState {
         sessions,
         client: client.clone(),
         upstream: Arc::new(upstream.clone()),
         api_key: api_key.clone(),
         upstream_request: upstream_request.clone(),
+        corpus,
     };
     info!(
         "session retention: store={} dir={} ttl={}h max_sessions={} max_session_memory={} MiB",
@@ -602,6 +624,7 @@ async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Respo
     );
     let url = format!("{}chat/completions", join_base(&state.upstream));
 
+    let previous_response_id = req.previous_response_id.clone();
     if req.stream {
         let response_id = state.sessions.new_id();
         chat_req.stream = true;
@@ -617,11 +640,13 @@ async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Respo
             request_messages,
             namespace_tools,
             model,
+            corpus: state.corpus,
+            previous_response_id,
         })
         .into_response()
     } else {
         chat_req.stream = false;
-        handle_blocking(state, chat_req, url, model, namespace_tools).await
+        handle_blocking(state, chat_req, url, model, namespace_tools, previous_response_id).await
     }
 }
 
@@ -724,6 +749,7 @@ async fn handle_blocking(
     url: String,
     model: String,
     namespace_tools: translate::NamespaceToolMap,
+    previous_response_id: Option<String>,
 ) -> Response {
     let mut builder = state
         .client
@@ -782,7 +808,16 @@ async fn handle_blocking(
 
                 let mut full_history = chat_req.messages.clone();
                 full_history.push(assistant_msg);
-                let response_id = state.sessions.save(full_history);
+                let response_id = state.sessions.new_id();
+                if let Some(corpus) = &state.corpus {
+                    corpus.record_turn(
+                        previous_response_id.as_deref(),
+                        &response_id,
+                        &model,
+                        &full_history,
+                    );
+                }
+                state.sessions.save_with_id(response_id.clone(), full_history);
 
                 let (resp, _) = if namespace_tools.is_empty() {
                     translate::from_chat_response(response_id, &model, chat_resp)

--- a/src/session.rs
+++ b/src/session.rs
@@ -252,7 +252,8 @@ impl SessionStore {
         state.enforce_limits();
     }
 
-    /// Allocate an id and store atomically (non-streaming path).
+    /// Allocate an id and store atomically.
+    #[allow(dead_code)]
     pub fn save(&self, messages: Vec<ChatMessage>) -> String {
         let id = self.new_id();
         self.save_with_id(id.clone(), messages);

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use tracing::{debug, error, warn};
 
 use crate::{
+    corpus::CorpusRecorder,
     session::SessionStore,
     translate::{response_function_name_for_responses, NamespaceToolMap},
     types::{ChatMessage, ChatRequest, ChatStreamChunk, ChatUsage},
@@ -31,6 +32,8 @@ pub struct StreamArgs {
     pub request_messages: Vec<ChatMessage>,
     pub namespace_tools: NamespaceToolMap,
     pub model: String,
+    pub corpus: Option<CorpusRecorder>,
+    pub previous_response_id: Option<String>,
 }
 
 struct ToolCallAccum {
@@ -74,6 +77,8 @@ pub fn translate_stream(
         request_messages,
         namespace_tools,
         model,
+        corpus,
+        previous_response_id,
     } = args;
     let msg_item_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
     let reasoning_item_id = format!("rs_{}", uuid::Uuid::new_v4().simple());
@@ -411,6 +416,14 @@ pub fn translate_stream(
             // so that history is complete for the next turn.
             let mut messages = request_messages;
             messages.push(assistant_msg);
+            if let Some(corpus) = &corpus {
+                corpus.record_turn(
+                    previous_response_id.as_deref(),
+                    &response_id,
+                    &model,
+                    &messages,
+                );
+            }
             sessions.save_with_id(response_id.clone(), messages);
 
             // Build output array for response.completed


### PR DESCRIPTION
## What

Adds an **opt-in**, append-only recorder that writes the conversation flow of each completed turn to daily-sharded JSONL files in **OpenAI messages format**, for building fine-tuning/SFT datasets.

Enable with `--record-corpus <dir>` (env `CODEX_RELAY_RECORD_CORPUS`). Off by default.

## Design (per discussion)

- **Incremental turn events** — each line records only the messages new to that turn. Full conversations are reconstructed by concatenating `messages` across events sharing a `conversation_id`.
- **Fully independent subsystem** — a new `CorpusRecorder` (`src/corpus.rs`) with its own bounded LRU index, completely separate from the evictable `SessionStore`. The corpus is a durable archive; the session store is a continuation cache.
- **Keeps tool_calls** — the payload uses the standard OpenAI schema and preserves `tool_calls`, `role:"tool"` outputs (`tool_call_id`), and assistant `reasoning_content` (zero translation from the internal `ChatMessage`).
- **Chain diffing** — keyed by `response_id`; child `full = parent history + new input + assistant`, so `delta = full[parent_count..]`. Isolated `spawn_agent` children start their own `conversation_id`.
- **No new dependency** — daily date computed via Hinnant's `civil_from_days`.

Record shape:

```json
{
  "conversation_id": "resp_abc…",
  "response_id": "resp_def…",
  "parent_response_id": "resp_abc…",
  "timestamp_unix_ms": 1783447750503,
  "model": "deepseek-chat",
  "messages": [ { "role": "user", "content": "…" }, { "role": "assistant", "content": "…" } ]
}
```

## Format rationale

OpenAI messages JSONL is the de-facto standard (HuggingFace TRL default, OpenAI fine-tuning native), natively supports tool calls, and requires zero translation from the relay's internal types. ShareGPT/Harmony can be produced offline from it, not the reverse without loss.

## Taps

Both completion points: blocking (`handle_blocking`) and streaming (`stream_done` branch).

## Privacy

Records contain prompts, tool call **arguments**, and tool outputs — more than the debug logs ever emit. Off by default; startup logs a sensitivity warning; README flags it, especially combined with `--bind`.

## Testing

- `cargo test` — 163 tests green (5 new corpus unit tests: delta diffing, tool_calls/reasoning preservation, isolated-child conversation, date conversion).
- `cargo clippy` — clean (pre-existing unrelated `ContentPart` warning only).
- **Installed locally (`cargo install --path .`) and load-tested end-to-end** against a concurrent mock upstream: 8 parallel conversation threads (4 streaming + 4 blocking) × 5 turns. Verified: no duplicate events, correct parent pointers, single `conversation_id` per chain, system prompt once per thread, ordered user turns, **no cross-thread contamination**, and correct delta reconstruction (11 messages each). The README `jq` fold command was verified against the output.

## Other

- Python `start()` gains a `record_corpus` parameter for parity.