### PR TITLE
Support native custom apply_patch tool calls

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -617,6 +617,7 @@ async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Respo
 
     let model = req.model.clone();
     let namespace_tools = translate::namespace_tool_map(&req.tools);
+    let custom_tools = translate::custom_tool_map(&req.tools);
     let mut chat_req = translate::to_chat_request(&req, history, &state.sessions);
     debug!(
         "→ upstream tools={}",
@@ -639,6 +640,7 @@ async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Respo
             sessions: state.sessions,
             request_messages,
             namespace_tools,
+            custom_tools,
             model,
             corpus: state.corpus,
             previous_response_id,
@@ -646,7 +648,16 @@ async fn handle_responses_inner(state: AppState, req: ResponsesRequest) -> Respo
         .into_response()
     } else {
         chat_req.stream = false;
-        handle_blocking(state, chat_req, url, model, namespace_tools, previous_response_id).await
+        handle_blocking(
+            state,
+            chat_req,
+            url,
+            model,
+            namespace_tools,
+            custom_tools,
+            previous_response_id,
+        )
+        .await
     }
 }
 
@@ -749,6 +760,7 @@ async fn handle_blocking(
     url: String,
     model: String,
     namespace_tools: translate::NamespaceToolMap,
+    custom_tools: translate::CustomToolMap,
     previous_response_id: Option<String>,
 ) -> Response {
     let mut builder = state
@@ -819,14 +831,15 @@ async fn handle_blocking(
                 }
                 state.sessions.save_with_id(response_id.clone(), full_history);
 
-                let (resp, _) = if namespace_tools.is_empty() {
+                let (resp, _) = if namespace_tools.is_empty() && custom_tools.is_empty() {
                     translate::from_chat_response(response_id, &model, chat_resp)
                 } else {
-                    translate::from_chat_response_with_tool_map(
+                    translate::from_chat_response_with_tool_maps(
                         response_id,
                         &model,
                         chat_resp,
                         &namespace_tools,
+                        &custom_tools,
                     )
                 };
                 Json(resp).into_response()

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -13,7 +13,9 @@ use tracing::{debug, error, warn};
 use crate::{
     corpus::CorpusRecorder,
     session::SessionStore,
-    translate::{response_function_name_for_responses, NamespaceToolMap},
+    translate::{
+        custom_tool_input, response_function_name_for_responses, CustomToolMap, NamespaceToolMap,
+    },
     types::{ChatMessage, ChatRequest, ChatStreamChunk, ChatUsage},
     upstream_request::UpstreamRequestConfig,
 };
@@ -31,6 +33,7 @@ pub struct StreamArgs {
     /// recovered when Codex replays the conversation without previous_response_id.
     pub request_messages: Vec<ChatMessage>,
     pub namespace_tools: NamespaceToolMap,
+    pub custom_tools: CustomToolMap,
     pub model: String,
     pub corpus: Option<CorpusRecorder>,
     pub previous_response_id: Option<String>,
@@ -76,6 +79,7 @@ pub fn translate_stream(
         sessions,
         request_messages,
         namespace_tools,
+        custom_tools,
         model,
         corpus,
         previous_response_id,
@@ -313,29 +317,58 @@ pub fn translate_stream(
         );
 
         for (rel_idx, (_, tc)) in tool_calls.iter().enumerate() {
-            let fc_item_id = format!("fc_{}", uuid::Uuid::new_v4().simple());
             let output_index = base_index + rel_idx;
             let (namespace, name) = response_function_name_for_responses(&tc.name, &namespace_tools);
-            let mut added_item = json!({
-                "type": "function_call",
-                "id": &fc_item_id,
-                "call_id": &tc.id,
-                "name": &name,
-                "arguments": "",
-                "status": "in_progress"
-            });
-            let mut done_item = json!({
-                "type": "function_call",
-                "id": &fc_item_id,
-                "call_id": &tc.id,
-                "name": &name,
-                "arguments": &tc.arguments,
-                "status": "completed"
-            });
-            if let Some(namespace) = namespace {
-                added_item["namespace"] = Value::String(namespace.clone());
-                done_item["namespace"] = Value::String(namespace);
-            }
+            let custom = custom_tools.get(&tc.name);
+            let fc_item_id = if custom.is_some() {
+                format!("ctc_{}", uuid::Uuid::new_v4().simple())
+            } else {
+                format!("fc_{}", uuid::Uuid::new_v4().simple())
+            };
+            let custom_input = custom
+                .map(|tool| custom_tool_input(&tc.arguments, &tool.argument_field));
+            let (added_item, done_item) = if let (Some(custom), Some(input)) = (custom, custom_input.as_deref()) {
+                (
+                    json!({
+                        "type": "custom_tool_call",
+                        "id": &fc_item_id,
+                        "call_id": &tc.id,
+                        "name": &custom.name,
+                        "input": "",
+                        "status": "in_progress"
+                    }),
+                    json!({
+                        "type": "custom_tool_call",
+                        "id": &fc_item_id,
+                        "call_id": &tc.id,
+                        "name": &custom.name,
+                        "input": input,
+                        "status": "completed"
+                    }),
+                )
+            } else {
+                let mut added = json!({
+                    "type": "function_call",
+                    "id": &fc_item_id,
+                    "call_id": &tc.id,
+                    "name": &name,
+                    "arguments": "",
+                    "status": "in_progress"
+                });
+                let mut done = json!({
+                    "type": "function_call",
+                    "id": &fc_item_id,
+                    "call_id": &tc.id,
+                    "name": &name,
+                    "arguments": &tc.arguments,
+                    "status": "completed"
+                });
+                if let Some(namespace) = namespace {
+                    added["namespace"] = Value::String(namespace.clone());
+                    done["namespace"] = Value::String(namespace);
+                }
+                (added, done)
+            };
 
             yield Ok(Event::default()
                 .event("response.output_item.added")
@@ -345,7 +378,18 @@ pub fn translate_stream(
                     "item": added_item
                 }).to_string()));
 
-            if !tc.arguments.is_empty() {
+            if let Some(input) = custom_input.as_deref() {
+                if !input.is_empty() {
+                    yield Ok(Event::default()
+                        .event("response.custom_tool_call_input.delta")
+                        .data(json!({
+                            "type": "response.custom_tool_call_input.delta",
+                            "item_id": &fc_item_id,
+                            "output_index": output_index,
+                            "delta": input
+                        }).to_string()));
+                }
+            } else if !tc.arguments.is_empty() {
                 yield Ok(Event::default()
                     .event("response.function_call_arguments.delta")
                     .data(json!({

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -11,6 +11,14 @@ pub struct NamespaceToolName {
 
 pub type NamespaceToolMap = HashMap<String, NamespaceToolName>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CustomToolName {
+    pub name: String,
+    pub argument_field: String,
+}
+
+pub type CustomToolMap = HashMap<String, CustomToolName>;
+
 /// Convert a Responses API request + prior history into a Chat Completions request.
 pub fn to_chat_request(
     req: &ResponsesRequest,
@@ -82,7 +90,7 @@ pub fn to_chat_request(
                 let item = &items[i];
                 let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
-                if item_type == "function_call" {
+                if matches!(item_type, "function_call" | "custom_tool_call") {
                     // Skip function_call items whose call_id already exists in history.
                     // Duplicates occur when both previous_response_id and input replay
                     // the same function_call entries from prior output.
@@ -91,23 +99,28 @@ pub fn to_chat_request(
                         i += 1;
                         continue;
                     }
-                    // Collect this and all immediately following function_call items
+                    // Collect this and all immediately following tool call items
                     // into one assistant message with multiple tool_calls entries.
                     let mut grouped: Vec<Value> = Vec::new();
                     let mut reasoning_content: Option<String> = None;
 
                     while i < items.len() {
                         let cur = &items[i];
-                        if cur.get("type").and_then(|v| v.as_str()).unwrap_or("") != "function_call"
-                        {
+                        let cur_type = cur.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                        if !matches!(cur_type, "function_call" | "custom_tool_call") {
                             break;
                         }
                         let call_id = cur.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
                         let name = response_function_name_for_chat(cur);
-                        let args = cur
-                            .get("arguments")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("{}");
+                        let args = if cur_type == "custom_tool_call" {
+                            let input = cur.get("input").and_then(Value::as_str).unwrap_or("");
+                            json!({ custom_argument_field(&name): input }).to_string()
+                        } else {
+                            cur.get("arguments")
+                                .and_then(Value::as_str)
+                                .unwrap_or("{}")
+                                .to_string()
+                        };
                         if reasoning_content.is_none() {
                             reasoning_content = sessions.get_reasoning(call_id);
                         }
@@ -134,7 +147,7 @@ pub fn to_chat_request(
                     messages.push(msg);
                 } else {
                     match item_type {
-                        "function_call_output" => {
+                        "function_call_output" | "custom_tool_call_output" => {
                             let call_id =
                                 item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
                             // Skip function_call_output items if a tool response
@@ -295,6 +308,38 @@ pub fn namespace_tool_map(tools: &[Value]) -> NamespaceToolMap {
     map
 }
 
+pub fn custom_tool_map(tools: &[Value]) -> CustomToolMap {
+    tools
+        .iter()
+        .filter(|tool| tool.get("type").and_then(Value::as_str) == Some("custom"))
+        .filter_map(|tool| {
+            let name = tool.get("name").and_then(Value::as_str)?;
+            Some((
+                name.to_string(),
+                CustomToolName {
+                    name: name.to_string(),
+                    argument_field: custom_argument_field(name).to_string(),
+                },
+            ))
+        })
+        .collect()
+}
+
+fn custom_argument_field(name: &str) -> &'static str {
+    if name == "apply_patch" {
+        "patch"
+    } else {
+        "input"
+    }
+}
+
+pub(crate) fn custom_tool_input(arguments: &str, argument_field: &str) -> String {
+    serde_json::from_str::<Value>(arguments)
+        .ok()
+        .and_then(|value| value.get(argument_field)?.as_str().map(String::from))
+        .unwrap_or_else(|| arguments.to_string())
+}
+
 fn tool_denylist_from_env() -> HashSet<String> {
     std::env::var("CODEX_RELAY_TOOL_DENYLIST")
         .unwrap_or_default()
@@ -329,6 +374,34 @@ fn convert_tools_with_denylist(tools: &[Value], denied: &HashSet<String>) -> Vec
                         }
                     }
                 }
+            }
+            Some("custom") => {
+                let Some(name) = tool.get("name").and_then(Value::as_str) else {
+                    continue;
+                };
+                if denied.contains(name) {
+                    continue;
+                }
+                let argument_field = custom_argument_field(name);
+                let description = tool
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Provide the raw custom tool input.");
+                out.push(json!({
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "description": description,
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                argument_field: {"type": "string"}
+                            },
+                            "required": [argument_field],
+                            "additionalProperties": false
+                        }
+                    }
+                }));
             }
             _ => {}
         }
@@ -431,6 +504,16 @@ pub fn from_chat_response_with_tool_map(
     chat: ChatResponse,
     namespace_tools: &NamespaceToolMap,
 ) -> (ResponsesResponse, Vec<ChatMessage>) {
+    from_chat_response_with_tool_maps(id, model, chat, namespace_tools, &CustomToolMap::new())
+}
+
+pub fn from_chat_response_with_tool_maps(
+    id: String,
+    model: &str,
+    chat: ChatResponse,
+    namespace_tools: &NamespaceToolMap,
+    custom_tools: &CustomToolMap,
+) -> (ResponsesResponse, Vec<ChatMessage>) {
     let choice = chat
         .choices
         .into_iter()
@@ -471,20 +554,30 @@ pub fn from_chat_response_with_tool_map(
                 .get("arguments")
                 .and_then(Value::as_str)
                 .unwrap_or("{}");
-            let mut item = json!({
-                "type": "function_call",
-                "id": format!("fc_{}", uuid::Uuid::new_v4().simple()),
-                "call_id": tool_call
-                    .get("id")
-                    .and_then(Value::as_str)
-                    .unwrap_or(""),
-                "name": name,
-                "arguments": arguments,
-                "status": "completed"
-            });
-            if let Some(namespace) = namespace {
-                item["namespace"] = Value::String(namespace);
-            }
+            let call_id = tool_call.get("id").and_then(Value::as_str).unwrap_or("");
+            let item = if let Some(custom) = custom_tools.get(raw_name) {
+                json!({
+                    "type": "custom_tool_call",
+                    "id": format!("ctc_{}", uuid::Uuid::new_v4().simple()),
+                    "call_id": call_id,
+                    "name": custom.name,
+                    "input": custom_tool_input(arguments, &custom.argument_field),
+                    "status": "completed"
+                })
+            } else {
+                let mut item = json!({
+                    "type": "function_call",
+                    "id": format!("fc_{}", uuid::Uuid::new_v4().simple()),
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": arguments,
+                    "status": "completed"
+                });
+                if let Some(namespace) = namespace {
+                    item["namespace"] = Value::String(namespace);
+                }
+                item
+            };
             output.push(item);
         }
     }
@@ -676,6 +769,37 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0]["id"], "c1");
         assert_eq!(calls[1]["id"], "c2");
+    }
+
+    #[test]
+    fn test_custom_tool_call_and_output_replay_as_chat_messages() {
+        let sessions = SessionStore::new();
+        let patch = "*** Begin Patch\n*** End Patch";
+        let req = base_req(ResponsesInput::Messages(vec![
+            json!({
+                "type": "custom_tool_call",
+                "call_id": "call_patch",
+                "name": "apply_patch",
+                "input": patch
+            }),
+            json!({
+                "type": "custom_tool_call_output",
+                "call_id": "call_patch",
+                "output": "Done!"
+            }),
+        ]));
+
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert_eq!(chat.messages.len(), 2);
+        let call = &chat.messages[0].tool_calls.as_ref().unwrap()[0];
+        assert_eq!(call["function"]["name"], "apply_patch");
+        assert_eq!(
+            serde_json::from_str::<Value>(call["function"]["arguments"].as_str().unwrap()).unwrap(),
+            json!({"patch": patch})
+        );
+        assert_eq!(chat.messages[1].role, "tool");
+        assert_eq!(chat.messages[1].tool_call_id.as_deref(), Some("call_patch"));
+        assert_eq!(chat.messages[1].text_content(), "Done!");
     }
 
     #[test]

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -13,7 +13,8 @@ use axum::{
 };
 use codex_relay::session::SessionStore;
 use codex_relay::translate::{
-    from_chat_response_with_tool_map, namespace_tool_map, to_chat_request,
+    custom_tool_map, from_chat_response_with_tool_map, from_chat_response_with_tool_maps,
+    namespace_tool_map, to_chat_request,
 };
 use codex_relay::types::{ChatChoice, ChatMessage, ChatResponse, ChatUsage, ResponsesRequest};
 use eventsource_stream::Eventsource;
@@ -126,6 +127,65 @@ fn issue_20_blocking_hyphen_flat_tool_name_is_not_namespaced() {
     assert_eq!(resp.output[0]["type"], "function_call");
     assert!(resp.output[0].get("namespace").is_none());
     assert_eq!(resp.output[0]["name"], "foo-bar");
+}
+
+#[test]
+fn issue_37_custom_apply_patch_round_trips_in_blocking_translation() {
+    let tools = vec![json!({
+        "type": "custom",
+        "name": "apply_patch",
+        "description": "Apply a patch"
+    })];
+    let req: ResponsesRequest = serde_json::from_value(json!({
+        "model": "mock-model",
+        "input": "Update the file.",
+        "tools": tools,
+        "stream": false
+    }))
+    .unwrap();
+    let chat_req = to_chat_request(&req, Vec::new(), &SessionStore::new());
+    assert_eq!(chat_req.tools[0]["type"], "function");
+    assert_eq!(chat_req.tools[0]["function"]["name"], "apply_patch");
+    assert_eq!(
+        chat_req.tools[0]["function"]["parameters"]["required"],
+        json!(["patch"])
+    );
+
+    let patch = "*** Begin Patch\n*** Update File: test.txt\n@@\n-old\n+new\n*** End Patch";
+    let chat = ChatResponse {
+        choices: vec![ChatChoice {
+            message: ChatMessage {
+                role: "assistant".into(),
+                content: None,
+                reasoning_content: None,
+                tool_calls: Some(vec![json!({
+                    "id": "call_patch",
+                    "type": "function",
+                    "function": {
+                        "name": "apply_patch",
+                        "arguments": json!({"patch": patch}).to_string()
+                    }
+                })]),
+                tool_call_id: None,
+                name: None,
+            },
+        }],
+        usage: None,
+    };
+    let custom_tools = custom_tool_map(&req.tools);
+    let (response, _) = from_chat_response_with_tool_maps(
+        "resp_37".into(),
+        "mock-model",
+        chat,
+        &Default::default(),
+        &custom_tools,
+    );
+    let item = &response.output[0];
+    assert_eq!(item["type"], "custom_tool_call");
+    assert_eq!(item["name"], "apply_patch");
+    assert_eq!(item["call_id"], "call_patch");
+    assert_eq!(item["input"], patch);
+    assert!(item.get("arguments").is_none());
 }
 
 #[test]
@@ -866,6 +926,93 @@ async fn issue_20_streaming_hyphen_flat_tool_name_is_not_namespaced() {
     let item = &completed["response"]["output"][0];
     assert!(item.get("namespace").is_none());
     assert_eq!(item["name"], "foo-bar");
+}
+
+#[tokio::test]
+async fn issue_37_streaming_apply_patch_emits_custom_tool_events() {
+    let patch = "*** Begin Patch\n*** Update File: test.txt\n@@\n-old\n+new\n*** End Patch";
+    let arguments = json!({"patch": patch}).to_string();
+    let tool_sse = sse_from_chunks(vec![
+        json!({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_patch",
+                        "function": {
+                            "name": "apply_patch",
+                            "arguments": arguments
+                        }
+                    }]
+                }
+            }]
+        }),
+        json!({"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":3,"total_tokens":14}}),
+    ]);
+    let (upstream_port, bodies) = spawn_mock_upstream_with_responses(vec![tool_sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "input": "Apply the change.",
+            "tools": [{
+                "type": "custom",
+                "name": "apply_patch",
+                "description": "Apply a patch"
+            }],
+            "stream": true
+        }),
+    )
+    .await;
+
+    let added = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.added" && data["item"]["type"] == "custom_tool_call"
+        })
+        .map(|(_, data)| &data["item"])
+        .expect("custom_tool_call added item");
+    assert_eq!(added["name"], "apply_patch");
+    assert_eq!(added["input"], "");
+    assert!(added.get("arguments").is_none());
+
+    let delta = events
+        .iter()
+        .find(|(event, _)| event == "response.custom_tool_call_input.delta")
+        .map(|(_, data)| data)
+        .expect("custom tool input delta");
+    assert_eq!(delta["delta"], patch);
+
+    let done = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.done" && data["item"]["type"] == "custom_tool_call"
+        })
+        .map(|(_, data)| &data["item"])
+        .expect("custom_tool_call done item");
+    assert_eq!(done["input"], patch);
+
+    let completed = events
+        .iter()
+        .find_map(|(event, data)| (event == "response.completed").then_some(data))
+        .expect("response.completed");
+    assert_eq!(
+        completed["response"]["output"][0]["type"],
+        "custom_tool_call"
+    );
+    assert_eq!(completed["response"]["output"][0]["input"], patch);
+
+    let request_bodies = bodies.lock().unwrap();
+    assert_eq!(
+        request_bodies[0]["tools"][0]["function"]["name"],
+        "apply_patch"
+    );
+    assert_eq!(
+        request_bodies[0]["tools"][0]["function"]["parameters"]["required"],
+        json!(["patch"])
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- translate Responses API `custom` tools into Chat Completions function schemas for upstream providers
- preserve request-scoped custom tool metadata and restore upstream calls as `custom_tool_call` items
- emit `response.custom_tool_call_input.delta` events and include custom items in `response.completed.output`
- replay `custom_tool_call` and `custom_tool_call_output` input items into Chat Completions history
- keep existing function and namespace tool behavior unchanged

## Root cause

Codex registers `apply_patch` as a Responses API custom tool, while Chat Completions providers can only call it through a normal function-tool shape. The relay previously discarded custom tools when building the upstream request and always translated returned tool calls into `function_call` items. Codex therefore received JSON-wrapped `arguments` instead of the raw custom-tool `input` it expects.

## Implementation

The relay now builds a request-scoped custom tool map alongside the existing namespace map. Custom tools are exposed upstream as functions with one string argument. `apply_patch` uses the conventional `patch` argument; other custom tools use `input`.

When an upstream call matches the custom tool map, blocking and streaming response paths unwrap the string argument and restore the Responses API custom-tool representation. Invalid or unexpected JSON falls back to the original argument text so tool input is not lost.

The replay translator also accepts both `custom_tool_call` and `custom_tool_call_output`, wrapping raw custom input back into the Chat Completions function arguments required for the next model turn.

## Validation

- `cargo check`
- `cargo test`
- 167 non-ignored tests passed
- 12 existing external-provider live tests remained ignored
- added issue #37 coverage for upstream request conversion, blocking output, streaming added/delta/done/completed events, and next-turn replay

Fixes #37
