### PR TITLE
Detect apply_patch by name (#37) and heal leaked DeepSeek DSML tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ codex-relay --upstream https://api.deepseek.com/v1 --api-key "$DEEPSEEK_API_KEY"
 | `CODEX_RELAY_DROP_PARAMS` | _(empty)_ | JSON array of top-level upstream request parameter names to remove before forwarding |
 | `CODEX_RELAY_MODEL_MAP` | _(empty)_ | Comma-separated `source:target` model name translations (e.g., `gpt-5.4:deepseek-v4-pro`) |
 | `CODEX_RELAY_TOOL_DENYLIST` | _(empty)_ | Comma-separated tool names to remove before forwarding tools to the upstream model |
+| `CODEX_RELAY_DISABLE_QUIRKS` | _(empty)_ | Comma-separated [platform quirk](#platform-quirks) names to disable (e.g. `dsml_heal,glm_thinking`) |
 | `CODEX_RELAY_SESSION_TTL_HOURS` | `168` | Retain idle session/reasoning state for this many hours |
 | `CODEX_RELAY_MAX_SESSIONS` | `256` | Maximum completed response histories retained for `previous_response_id` |
 | `CODEX_RELAY_MAX_SESSION_MEMORY_MB` | `512` | Approximate memory budget for retained session/reasoning state |
@@ -147,6 +148,22 @@ codex-relay --upstream https://api.deepseek.com/v1 --api-key "$DEEPSEEK_API_KEY"
 | `CODEX_RELAY_HISTORY_DIR` | `.codex-relay-history` | Directory for disk-backed history records |
 | `CODEX_RELAY_RECORD_CORPUS` | _(off)_ | Directory to append per-turn conversation records (OpenAI messages JSONL); off unless set |
 | `RUST_LOG` | `codex_relay=info` | Log verbosity |
+
+## Platform quirks
+
+Some providers need workarounds that are not part of the Responses ⇄ Chat Completions translation itself. These are registered as named quirks (see `src/quirks.rs` for the full registry, triggers, and removal criteria):
+
+| Quirk | Kind | What it does |
+|---|---|---|
+| `glm_thinking` | request-shaping | Sends `thinking: enabled` for GLM/Zhipu models so they emit `reasoning_content` (issue #26) |
+| `dsml_heal` | response-healing | Parses DeepSeek V4's intermittently leaked DSML tool-call markup in text content back into structured tool calls |
+| `missing_done` | response-healing | Treats a cleanly closed SSE stream without `[DONE]` as complete when a full turn was received (issue #31) |
+
+Response-healing quirks activate only when the anomaly is detected and log a `quirk <name> fired` warning each time, so you can tell from the logs whether a workaround is still needed. Once the platform fixes the underlying bug, disable a quirk immediately with:
+
+```bash
+CODEX_RELAY_DISABLE_QUIRKS=dsml_heal codex-relay
+```
 
 ## Python API
 

--- a/src/dsml.rs
+++ b/src/dsml.rs
@@ -1,0 +1,375 @@
+//! Healing for leaked DeepSeek DSML tool-call markup.
+//!
+//! DeepSeek V3.2/V4 models emit tool calls as DSML markup which the provider
+//! is supposed to parse into structured `tool_calls`. Intermittently —
+//! especially with `tool_choice=auto` + streaming, or when a parameter value
+//! contains newlines — the raw markup leaks into the assistant `content`
+//! instead:
+//!
+//! ```text
+//! <｜DSML｜tool_calls>
+//! <｜DSML｜invoke name="shell">
+//! <｜DSML｜parameter name="command" string="true">Get-Content 'a.csv' -TotalCount 5</｜DSML｜parameter>
+//! </｜DSML｜invoke>
+//! </｜DSML｜tool_calls>
+//! ```
+//!
+//! Codex then sees plain text, no tool runs, and the turn silently stalls.
+//! This module parses leaked DSML back into structured tool calls and strips
+//! the markup from the visible text. The `｜` (U+FF5C) delimiters are
+//! DeepSeek-internal tokens that never appear in legitimate output, so
+//! healing is always on.
+
+use serde_json::{json, Value};
+
+use crate::types::ChatMessage;
+
+/// Prefix common to every DSML tag.
+pub const DSML_MARKER: &str = "<｜DSML｜";
+
+const INVOKE_OPEN: &str = "<｜DSML｜invoke";
+const INVOKE_CLOSE: &str = "</｜DSML｜invoke>";
+const PARAM_OPEN: &str = "<｜DSML｜parameter";
+const PARAM_CLOSE: &str = "</｜DSML｜parameter>";
+const CALLS_OPEN: &str = "<｜DSML｜tool_calls>";
+const CALLS_CLOSE: &str = "</｜DSML｜tool_calls>";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DsmlToolCall {
+    pub name: String,
+    /// JSON-encoded arguments object, ready for Chat Completions `function.arguments`.
+    pub arguments: String,
+}
+
+/// Parse leaked DSML tool-call markup out of `text`.
+///
+/// Returns the cleaned visible text plus the parsed calls, or `None` when no
+/// complete `<｜DSML｜invoke>` block could be parsed (the text is then left
+/// untouched so nothing is lost).
+pub fn parse_leaked_tool_calls(text: &str) -> Option<(String, Vec<DsmlToolCall>)> {
+    let mut calls = Vec::new();
+    let mut cleaned = String::new();
+    let mut rest = text;
+
+    while let Some(start) = rest.find(INVOKE_OPEN) {
+        let header_start = start + INVOKE_OPEN.len();
+        let Some(header_len) = unquoted_char(&rest[header_start..], '>') else {
+            break;
+        };
+        let header = &rest[header_start..header_start + header_len];
+        let body_start = header_start + header_len + 1;
+        let Some(body_len) = rest[body_start..].find(INVOKE_CLOSE) else {
+            break;
+        };
+        let Some(name) = attribute(header, "name") else {
+            break;
+        };
+        let arguments = parse_parameters(&rest[body_start..body_start + body_len]);
+        calls.push(DsmlToolCall {
+            name: name.to_string(),
+            arguments: Value::Object(arguments).to_string(),
+        });
+        cleaned.push_str(&rest[..start]);
+        rest = &rest[body_start + body_len + INVOKE_CLOSE.len()..];
+    }
+
+    if calls.is_empty() {
+        return None;
+    }
+    cleaned.push_str(rest);
+    let cleaned = cleaned.replace(CALLS_OPEN, "").replace(CALLS_CLOSE, "");
+    Some((cleaned.trim().to_string(), calls))
+}
+
+fn parse_parameters(body: &str) -> serde_json::Map<String, Value> {
+    let mut arguments = serde_json::Map::new();
+    let mut rest = body;
+    while let Some(start) = rest.find(PARAM_OPEN) {
+        let header_start = start + PARAM_OPEN.len();
+        let Some(header_len) = unquoted_char(&rest[header_start..], '>') else {
+            break;
+        };
+        let header = &rest[header_start..header_start + header_len];
+        let value_start = header_start + header_len + 1;
+        let Some(value_len) = rest[value_start..].find(PARAM_CLOSE) else {
+            break;
+        };
+        let raw = &rest[value_start..value_start + value_len];
+        if let Some(name) = attribute(header, "name") {
+            // string="false" marks a non-string JSON value (number, bool, ...).
+            let value = if attribute(header, "string") == Some("false") {
+                serde_json::from_str::<Value>(raw.trim())
+                    .unwrap_or_else(|_| Value::String(raw.to_string()))
+            } else {
+                Value::String(raw.to_string())
+            };
+            arguments.insert(name.to_string(), value);
+        }
+        rest = &rest[value_start + value_len + PARAM_CLOSE.len()..];
+    }
+    arguments
+}
+
+/// Byte offset of the first `needle` in `text` that is outside double quotes.
+fn unquoted_char(text: &str, needle: char) -> Option<usize> {
+    let mut in_quotes = false;
+    for (i, c) in text.char_indices() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            c if c == needle && !in_quotes => return Some(i),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Extract a `key="value"` attribute from a DSML tag header.
+fn attribute<'a>(header: &'a str, key: &str) -> Option<&'a str> {
+    let mut rest = header;
+    loop {
+        let start = rest.find(key)?;
+        let after = &rest[start + key.len()..];
+        // Guard against matching `name` inside another attribute's key.
+        let preceded_ok = rest[..start].ends_with(char::is_whitespace) || start == 0;
+        if preceded_ok {
+            if let Some(after_eq) = after.strip_prefix("=\"") {
+                let end = after_eq.find('"')?;
+                return Some(&after_eq[..end]);
+            }
+        }
+        rest = after;
+    }
+}
+
+pub(crate) fn synthesize_call_id() -> String {
+    format!("call_dsml_{}", uuid::Uuid::new_v4().simple())
+}
+
+/// Heal a blocking Chat Completions assistant message in place: parse leaked
+/// DSML markup in its text content into structured `tool_calls` entries and
+/// strip the markup from the visible text.
+pub fn heal_chat_message(message: &mut ChatMessage) {
+    let text = message.text_content();
+    if !text.contains(DSML_MARKER) {
+        return;
+    }
+    let Some((cleaned, calls)) = parse_leaked_tool_calls(text) else {
+        return;
+    };
+    tracing::warn!(
+        "quirk dsml_heal fired: healed {} leaked DSML tool call(s) from blocking response",
+        calls.len()
+    );
+    message.content = if cleaned.is_empty() {
+        None
+    } else {
+        Some(Value::String(cleaned))
+    };
+    let tool_calls = message.tool_calls.get_or_insert_with(Vec::new);
+    for call in calls {
+        tool_calls.push(json!({
+            "id": synthesize_call_id(),
+            "type": "function",
+            "function": { "name": call.name, "arguments": call.arguments }
+        }));
+    }
+}
+
+/// Incremental DSML filter for streamed text content.
+///
+/// Feed content deltas through [`DsmlStreamFilter::push`]; it returns the text
+/// that is safe to emit downstream. Text that could be (part of) a DSML marker
+/// is withheld. Once a marker is confirmed the rest of the stream is buffered
+/// and [`DsmlStreamFilter::finish`] returns the cleaned leftover text plus the
+/// healed tool calls.
+#[derive(Debug)]
+pub struct DsmlStreamFilter {
+    pending: String,
+    in_dsml: bool,
+    enabled: bool,
+}
+
+impl Default for DsmlStreamFilter {
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
+
+impl DsmlStreamFilter {
+    /// A filter that heals when `enabled`, or passes all text through
+    /// untouched when the `dsml_heal` quirk is disabled.
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            pending: String::new(),
+            in_dsml: false,
+            enabled,
+        }
+    }
+
+    /// Append a content delta; returns the portion that is safe to emit now.
+    pub fn push(&mut self, delta: &str) -> String {
+        if !self.enabled {
+            return delta.to_string();
+        }
+        self.pending.push_str(delta);
+        if self.in_dsml {
+            return String::new();
+        }
+        if let Some(start) = self.pending.find(DSML_MARKER) {
+            self.in_dsml = true;
+            let emit = self.pending[..start].to_string();
+            self.pending.drain(..start);
+            return emit;
+        }
+        // Withhold the longest tail that could still grow into the marker.
+        let hold = longest_marker_prefix_suffix(&self.pending);
+        let emit_len = self.pending.len() - hold;
+        let emit = self.pending[..emit_len].to_string();
+        self.pending.drain(..emit_len);
+        emit
+    }
+
+    /// Consume the filter at end of stream. Returns any remaining visible text
+    /// and the tool calls healed from buffered DSML markup.
+    pub fn finish(self) -> (String, Vec<DsmlToolCall>) {
+        if !self.in_dsml {
+            return (self.pending, Vec::new());
+        }
+        match parse_leaked_tool_calls(&self.pending) {
+            Some((cleaned, calls)) => (cleaned, calls),
+            // Incomplete or unparseable markup: pass the raw text through so
+            // nothing is silently dropped.
+            None => (self.pending, Vec::new()),
+        }
+    }
+}
+
+/// Length in bytes of the longest suffix of `text` that is a proper prefix of
+/// [`DSML_MARKER`].
+fn longest_marker_prefix_suffix(text: &str) -> usize {
+    let mut best = 0;
+    for (i, _) in DSML_MARKER.char_indices().skip(1) {
+        if text.ends_with(&DSML_MARKER[..i]) {
+            best = i;
+        }
+    }
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ENVELOPE: &str = "<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"shell\">\n<｜DSML｜parameter name=\"command\" string=\"true\">Get-Content 'D:\\data\\a.csv' -Encoding UTF8 -TotalCount 5</｜DSML｜parameter>\n<｜DSML｜parameter name=\"context\" string=\"true\">preview csv headers</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>";
+
+    #[test]
+    fn parses_leaked_envelope() {
+        let text = format!("我来读取文件。\n{ENVELOPE}");
+        let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("healed");
+        assert_eq!(cleaned, "我来读取文件。");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "shell");
+        let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert_eq!(
+            args["command"],
+            "Get-Content 'D:\\data\\a.csv' -Encoding UTF8 -TotalCount 5"
+        );
+        assert_eq!(args["context"], "preview csv headers");
+    }
+
+    #[test]
+    fn parses_multiline_and_nonstring_parameters() {
+        let text = "<｜DSML｜invoke name=\"bash\">\n<｜DSML｜parameter name=\"command\" string=\"true\">line one \\\nline two > out.txt</｜DSML｜parameter>\n<｜DSML｜parameter name=\"timeout\" string=\"false\">15</｜DSML｜parameter>\n</｜DSML｜invoke>";
+        let (cleaned, calls) = parse_leaked_tool_calls(text).expect("healed");
+        assert_eq!(cleaned, "");
+        let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert_eq!(args["command"], "line one \\\nline two > out.txt");
+        assert_eq!(args["timeout"], 15);
+    }
+
+    #[test]
+    fn parses_multiple_invokes() {
+        let text = format!("{ENVELOPE}\n{ENVELOPE}");
+        let (_, calls) = parse_leaked_tool_calls(&text).expect("healed");
+        assert_eq!(calls.len(), 2);
+    }
+
+    #[test]
+    fn plain_text_is_untouched() {
+        assert!(parse_leaked_tool_calls("no markup here, just a < b").is_none());
+        assert!(parse_leaked_tool_calls("<｜DSML｜tool_calls>dangling").is_none());
+    }
+
+    #[test]
+    fn stream_filter_passes_plain_text() {
+        let mut filter = DsmlStreamFilter::default();
+        assert_eq!(filter.push("hello "), "hello ");
+        assert_eq!(filter.push("a < b and c > d"), "a < b and c > d");
+        let (leftover, calls) = filter.finish();
+        assert_eq!(leftover, "");
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn stream_filter_holds_split_marker_and_heals() {
+        let mut filter = DsmlStreamFilter::default();
+        let mut emitted = String::new();
+        emitted.push_str(&filter.push("先看文件。<｜DS"));
+        emitted.push_str(&filter.push("ML｜tool_calls>\n<｜DSML｜invoke name=\"shell\">\n<｜DSML｜parameter name=\"command\" string=\"true\">ls</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜"));
+        emitted.push_str(&filter.push("tool_calls>"));
+        assert_eq!(emitted, "先看文件。");
+        let (leftover, calls) = filter.finish();
+        assert_eq!(leftover, "");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "shell");
+        let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert_eq!(args["command"], "ls");
+    }
+
+    #[test]
+    fn stream_filter_releases_false_marker_prefix() {
+        let mut filter = DsmlStreamFilter::default();
+        let first = filter.push("a <");
+        let second = filter.push("b> c");
+        assert_eq!(format!("{first}{second}"), "a <b> c");
+    }
+
+    #[test]
+    fn disabled_stream_filter_passes_markup_through() {
+        let mut filter = DsmlStreamFilter::new(false);
+        assert_eq!(filter.push(ENVELOPE), ENVELOPE);
+        let (leftover, calls) = filter.finish();
+        assert_eq!(leftover, "");
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn stream_filter_passes_incomplete_markup_through() {
+        let mut filter = DsmlStreamFilter::default();
+        filter.push("<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"shell\">truncat");
+        let (leftover, calls) = filter.finish();
+        assert!(calls.is_empty());
+        assert!(leftover.contains("truncat"), "raw text must not be lost");
+    }
+
+    #[test]
+    fn heal_chat_message_moves_markup_into_tool_calls() {
+        let mut message = ChatMessage {
+            role: "assistant".into(),
+            content: Some(Value::String(format!("我来逐步完成这个任务。\n{ENVELOPE}"))),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        };
+        heal_chat_message(&mut message);
+        assert_eq!(message.text_content(), "我来逐步完成这个任务。");
+        let tool_calls = message.tool_calls.as_ref().expect("healed tool_calls");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0]["function"]["name"], "shell");
+        assert!(tool_calls[0]["id"]
+            .as_str()
+            .unwrap()
+            .starts_with("call_dsml_"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod corpus;
+pub mod dsml;
+pub mod quirks;
 pub mod session;
 pub mod stream;
 pub mod translate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 mod corpus;
+mod dsml;
+mod quirks;
 mod session;
 mod stream;
 mod translate;

--- a/src/quirks.rs
+++ b/src/quirks.rs
@@ -1,0 +1,94 @@
+//! Registry of platform-specific quirks: workarounds for provider bugs or
+//! provider-specific behavior that is not part of the Responses ⇄ Chat
+//! Completions contract itself.
+//!
+//! # Quirk classes
+//!
+//! **Request-shaping (class A)** quirks proactively change what the relay
+//! sends upstream. They affect every request, so they must be gated by
+//! provider/model identity (e.g. model-name matching).
+//!
+//! **Response-healing (class B)** quirks repair malformed upstream responses.
+//! They are gated by detecting the anomaly itself and are no-ops on healthy
+//! responses — model-name or version gating would be both unreliable (OpenAI-
+//! compatible APIs rarely expose versions; the same broken model is served
+//! under many names by NIM/Ollama/vLLM hosts) and unnecessary (the trigger
+//! condition is precise). They self-deactivate once the platform fixes the
+//! bug.
+//!
+//! # Lifecycle and removal
+//!
+//! Every class-B quirk logs a `warn!` each time it fires. That telemetry is
+//! the removal signal: once the upstream fix ships and logs show no firings
+//! over a sustained period, the quirk is a deletion candidate. Until then,
+//! users can disable any quirk immediately — without waiting for a relay
+//! release — via:
+//!
+//! ```text
+//! CODEX_RELAY_DISABLE_QUIRKS=dsml_heal,glm_thinking
+//! ```
+//!
+//! # Registered quirks
+//!
+//! | name           | class | trigger                                   | remove when |
+//! |----------------|-------|-------------------------------------------|-------------|
+//! | `glm_thinking` | A     | model name looks like GLM/Zhipu           | GLM emits reasoning_content without the explicit `thinking` switch (issue #26) |
+//! | `dsml_heal`    | B     | leaked `<｜DSML｜` markup in text content  | DeepSeek V4 stops leaking DSML (vllm-project/vllm#40801) and telemetry shows no firings for ~a month |
+//! | `missing_done` | B     | SSE stream closes cleanly without `[DONE]`| providers (e.g. synthetic.new) terminate streams spec-compliantly (issue #31) |
+
+use std::collections::HashSet;
+
+/// Names of all registered quirks, for validation and documentation.
+pub const QUIRK_NAMES: &[&str] = &["glm_thinking", "dsml_heal", "missing_done"];
+
+/// Whether a quirk is enabled, honoring the `CODEX_RELAY_DISABLE_QUIRKS`
+/// kill switch (comma-separated quirk names, case-insensitive).
+pub fn quirk_enabled(name: &str) -> bool {
+    !disabled_quirks_from_env().contains(name)
+}
+
+fn disabled_quirks_from_env() -> HashSet<String> {
+    parse_disabled_quirks(&std::env::var("CODEX_RELAY_DISABLE_QUIRKS").unwrap_or_default())
+}
+
+fn parse_disabled_quirks(raw: &str) -> HashSet<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_ascii_lowercase)
+        .inspect(|name| {
+            if !QUIRK_NAMES.contains(&name.as_str()) {
+                tracing::warn!("CODEX_RELAY_DISABLE_QUIRKS: unknown quirk name `{name}`");
+            }
+        })
+        .collect()
+}
+
+/// Whether a model name looks like a GLM/Zhipu reasoning model that needs the
+/// explicit `thinking` switch to emit reasoning_content (quirk `glm_thinking`).
+pub fn is_glm_like_model(model: &str) -> bool {
+    let m = model.to_ascii_lowercase();
+    m.contains("glm") || m.contains("zhipu") || m.contains("bigmodel")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_disable_list() {
+        let disabled = parse_disabled_quirks("dsml_heal, GLM_THINKING");
+        assert!(disabled.contains("dsml_heal"));
+        assert!(disabled.contains("glm_thinking"));
+        assert!(!disabled.contains("missing_done"));
+        assert!(parse_disabled_quirks("").is_empty());
+    }
+
+    #[test]
+    fn glm_like_model_matching() {
+        assert!(is_glm_like_model("glm-5.2"));
+        assert!(is_glm_like_model("ZhipuAI/foo"));
+        assert!(is_glm_like_model("bigmodel-x"));
+        assert!(!is_glm_like_model("deepseek-v4-pro"));
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -13,6 +13,7 @@ use tracing::{debug, error, warn};
 
 use crate::{
     corpus::CorpusRecorder,
+    dsml::{synthesize_call_id, DsmlStreamFilter},
     session::SessionStore,
     translate::{
         custom_tool_input, response_function_name_for_responses, CustomToolMap, NamespaceToolMap,
@@ -134,6 +135,10 @@ pub fn translate_stream(
 
         let mut accumulated_text = String::new();
         let mut accumulated_reasoning = String::new();
+        // Withholds text that could be leaked DeepSeek DSML tool-call markup
+        // and heals it into structured tool calls at end of stream.
+        // Quirk `dsml_heal`, see quirks.rs.
+        let mut dsml_filter = DsmlStreamFilter::new(crate::quirks::quirk_enabled("dsml_heal"));
         let mut reasoning_chunks: usize = 0;
         let mut tool_calls: BTreeMap<usize, ToolCallAccum> = BTreeMap::new();
         let mut reasoning_output_index: Option<usize> = None;
@@ -204,8 +209,8 @@ pub fn translate_stream(
                                     }
                                 }
 
-                                // Text content
-                                let content = choice.delta.content.as_deref().unwrap_or("");
+                                // Text content, filtered for leaked DSML markup.
+                                let content = dsml_filter.push(choice.delta.content.as_deref().unwrap_or(""));
                                 if !content.is_empty() {
                                     let output_index = match message_output_index {
                                         Some(idx) => idx,
@@ -229,14 +234,14 @@ pub fn translate_stream(
                                             idx
                                         }
                                     };
-                                    accumulated_text.push_str(content);
+                                    accumulated_text.push_str(&content);
                                     yield Ok(Event::default()
                                         .event("response.output_text.delta")
                                         .data(json!({
                                             "type": "response.output_text.delta",
                                             "item_id": &msg_item_id,
                                             "output_index": output_index,
-                                            "delta": content
+                                            "delta": &content
                                         }).to_string()));
                                 }
 
@@ -269,6 +274,58 @@ pub fn translate_stream(
                         }
                     }
                 }
+            }
+        }
+
+        // Flush the DSML filter: healed tool calls join the accumulated
+        // tool_calls (and are emitted as function_call/custom_tool_call items
+        // below); any remaining visible text is emitted as a final delta.
+        let (dsml_leftover, dsml_calls) = dsml_filter.finish();
+        if !dsml_leftover.is_empty() {
+            let output_index = match message_output_index {
+                Some(idx) => idx,
+                None => {
+                    let idx = next_output_index;
+                    next_output_index += 1;
+                    message_output_index = Some(idx);
+                    yield Ok(Event::default()
+                        .event("response.output_item.added")
+                        .data(json!({
+                            "type": "response.output_item.added",
+                            "output_index": idx,
+                            "item": {
+                                "type": "message",
+                                "id": &msg_item_id,
+                                "role": "assistant",
+                                "status": "in_progress",
+                                "content": []
+                            }
+                        }).to_string()));
+                    idx
+                }
+            };
+            accumulated_text.push_str(&dsml_leftover);
+            yield Ok(Event::default()
+                .event("response.output_text.delta")
+                .data(json!({
+                    "type": "response.output_text.delta",
+                    "item_id": &msg_item_id,
+                    "output_index": output_index,
+                    "delta": &dsml_leftover
+                }).to_string()));
+        }
+        if !dsml_calls.is_empty() {
+            warn!(
+                "quirk dsml_heal fired: healed {} leaked DSML tool call(s) from stream",
+                dsml_calls.len()
+            );
+            let base_index = tool_calls.keys().max().map(|idx| idx + 1).unwrap_or(0);
+            for (offset, call) in dsml_calls.into_iter().enumerate() {
+                tool_calls.insert(base_index + offset, ToolCallAccum {
+                    id: synthesize_call_id(),
+                    name: call.name,
+                    arguments: call.arguments,
+                });
             }
         }
 
@@ -418,8 +475,12 @@ pub fn translate_stream(
         // (text and/or tool calls), treat it as complete so the response is
         // persisted and `response.completed` is emitted. A mid-stream error
         // (stream_err) still discards the partial turn.
-        if !stream_done && !stream_err && (!accumulated_text.is_empty() || !tool_calls.is_empty()) {
-            warn!("stream ended without [DONE] but content was received — treating as complete");
+        if !stream_done
+            && !stream_err
+            && (!accumulated_text.is_empty() || !tool_calls.is_empty())
+            && crate::quirks::quirk_enabled("missing_done")
+        {
+            warn!("quirk missing_done fired: stream ended without [DONE] but content was received — treating as complete");
             stream_done = true;
         }
 

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -58,6 +58,9 @@ pub fn to_chat_request(
             });
         }
         ResponsesInput::Messages(items) => {
+            // Request-scoped custom tool map so replayed custom_tool_call items
+            // are wrapped with the same argument field the tool declared.
+            let custom_tools = custom_tool_map(&req.tools);
             // Collect call_ids already present in history (from previous_response_id).
             // This prevents creating duplicate assistant-with-tool_calls messages
             // when the input items replay function_call entries from prior output.
@@ -114,7 +117,11 @@ pub fn to_chat_request(
                         let name = response_function_name_for_chat(cur);
                         let args = if cur_type == "custom_tool_call" {
                             let input = cur.get("input").and_then(Value::as_str).unwrap_or("");
-                            json!({ custom_argument_field(&name): input }).to_string()
+                            let argument_field = custom_tools
+                                .get(&name)
+                                .map(|tool| tool.argument_field.as_str())
+                                .unwrap_or_else(|| custom_argument_field(&name));
+                            json!({ argument_field: input }).to_string()
                         } else {
                             cur.get("arguments")
                                 .and_then(Value::as_str)
@@ -222,8 +229,10 @@ pub fn to_chat_request(
     // enabled; its default auto-thinking is suppressed by heavy agent system
     // prompts (e.g. Codex). Other providers (DeepSeek/Kimi) think by default and
     // must not receive this field, so it stays GLM-gated to preserve their
-    // request shape. See GitHub issue #26.
-    let enable_glm_thinking = is_glm_like_model(&req.model) || is_glm_like_model(&mapped_model);
+    // request shape. See GitHub issue #26 and the quirk registry in quirks.rs.
+    let enable_glm_thinking = crate::quirks::quirk_enabled("glm_thinking")
+        && (crate::quirks::is_glm_like_model(&req.model)
+            || crate::quirks::is_glm_like_model(&mapped_model));
 
     ChatRequest {
         model: mapped_model,
@@ -239,13 +248,6 @@ pub fn to_chat_request(
         }),
         stream: req.stream,
     }
-}
-
-/// Whether a model name looks like a GLM/Zhipu reasoning model that needs the
-/// explicit `thinking` switch to emit reasoning_content.
-fn is_glm_like_model(model: &str) -> bool {
-    let m = model.to_ascii_lowercase();
-    m.contains("glm") || m.contains("zhipu") || m.contains("bigmodel")
 }
 
 /// Map model names via `CODEX_RELAY_MODEL_MAP` env var.
@@ -311,18 +313,40 @@ pub fn namespace_tool_map(tools: &[Value]) -> NamespaceToolMap {
 pub fn custom_tool_map(tools: &[Value]) -> CustomToolMap {
     tools
         .iter()
-        .filter(|tool| tool.get("type").and_then(Value::as_str) == Some("custom"))
         .filter_map(|tool| {
+            let tool_type = tool.get("type").and_then(Value::as_str)?;
             let name = tool.get("name").and_then(Value::as_str)?;
+            let argument_field = match tool_type {
+                "custom" => custom_argument_field(name).to_string(),
+                // Codex CLI declares `apply_patch` as a plain function tool in
+                // some configurations (issue #37), but its handler only accepts
+                // `custom_tool_call` items, so treat it as custom by name. The
+                // argument field follows the declared schema (`patch` in recent
+                // Codex CLI, `input` in the historical JSON tool variant).
+                "function" if name == "apply_patch" => function_tool_string_field(tool)
+                    .unwrap_or_else(|| custom_argument_field(name).to_string()),
+                _ => return None,
+            };
             Some((
                 name.to_string(),
                 CustomToolName {
                     name: name.to_string(),
-                    argument_field: custom_argument_field(name).to_string(),
+                    argument_field,
                 },
             ))
         })
         .collect()
+}
+
+/// If a Responses API function tool takes a single string parameter, return
+/// that parameter's name.
+fn function_tool_string_field(tool: &Value) -> Option<String> {
+    let properties = tool.get("parameters")?.get("properties")?.as_object()?;
+    if properties.len() != 1 {
+        return None;
+    }
+    let (field, schema) = properties.iter().next()?;
+    (schema.get("type").and_then(Value::as_str) == Some("string")).then(|| field.clone())
 }
 
 fn custom_argument_field(name: &str) -> &'static str {
@@ -514,7 +538,7 @@ pub fn from_chat_response_with_tool_maps(
     namespace_tools: &NamespaceToolMap,
     custom_tools: &CustomToolMap,
 ) -> (ResponsesResponse, Vec<ChatMessage>) {
-    let choice = chat
+    let mut choice = chat
         .choices
         .into_iter()
         .next()
@@ -528,6 +552,14 @@ pub fn from_chat_response_with_tool_maps(
                 name: None,
             },
         });
+
+    // DeepSeek V4 intermittently leaks DSML tool-call markup into the text
+    // content instead of structured tool_calls; heal it before translation
+    // so the calls execute and the markup never reaches Codex or history.
+    // Quirk `dsml_heal`, see quirks.rs.
+    if crate::quirks::quirk_enabled("dsml_heal") {
+        crate::dsml::heal_chat_message(&mut choice.message);
+    }
 
     let usage = chat.usage.unwrap_or_default();
     tracing::debug!("cache(non-stream): {}", usage.cache_summary());

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -189,6 +189,309 @@ fn issue_37_custom_apply_patch_round_trips_in_blocking_translation() {
 }
 
 #[test]
+fn issue_37_function_declared_apply_patch_emits_custom_tool_call() {
+    // Codex CLI declares apply_patch as a plain function tool in some
+    // configurations, but still requires custom_tool_call items back.
+    let tools = vec![json!({
+        "type": "function",
+        "name": "apply_patch",
+        "description": "Use the `apply_patch` tool to edit files. This is a FREEFORM tool...",
+        "parameters": {
+            "type": "object",
+            "properties": { "patch": { "type": "string" } },
+            "required": ["patch"]
+        }
+    })];
+    let req: ResponsesRequest = serde_json::from_value(json!({
+        "model": "mock-model",
+        "input": "Update the file.",
+        "tools": tools,
+        "stream": false
+    }))
+    .unwrap();
+    // The declared function schema passes through to the upstream request.
+    let chat_req = to_chat_request(&req, Vec::new(), &SessionStore::new());
+    assert_eq!(chat_req.tools[0]["function"]["name"], "apply_patch");
+    assert_eq!(
+        chat_req.tools[0]["function"]["parameters"]["required"],
+        json!(["patch"])
+    );
+
+    let patch = "*** Begin Patch\n*** Update File: test.txt\n@@\n-old\n+new\n*** End Patch";
+    let chat = ChatResponse {
+        choices: vec![ChatChoice {
+            message: ChatMessage {
+                role: "assistant".into(),
+                content: None,
+                reasoning_content: None,
+                tool_calls: Some(vec![json!({
+                    "id": "call_patch_fn",
+                    "type": "function",
+                    "function": {
+                        "name": "apply_patch",
+                        "arguments": json!({"patch": patch}).to_string()
+                    }
+                })]),
+                tool_call_id: None,
+                name: None,
+            },
+        }],
+        usage: None,
+    };
+    let custom_tools = custom_tool_map(&req.tools);
+    let (response, _) = from_chat_response_with_tool_maps(
+        "resp_37_fn".into(),
+        "mock-model",
+        chat,
+        &Default::default(),
+        &custom_tools,
+    );
+    let item = &response.output[0];
+    assert_eq!(item["type"], "custom_tool_call");
+    assert_eq!(item["name"], "apply_patch");
+    assert_eq!(item["call_id"], "call_patch_fn");
+    assert_eq!(item["input"], patch);
+    assert!(item.get("arguments").is_none());
+}
+
+#[test]
+fn issue_37_function_declared_apply_patch_respects_input_argument_field() {
+    // Historical Codex CLI versions declared the JSON apply_patch variant
+    // with a single required `input` string parameter.
+    let tools = vec![json!({
+        "type": "function",
+        "name": "apply_patch",
+        "parameters": {
+            "type": "object",
+            "properties": { "input": { "type": "string" } },
+            "required": ["input"]
+        }
+    })];
+    let patch = "*** Begin Patch\n*** Update File: a.txt\n@@\n-x\n+y\n*** End Patch";
+    let chat = ChatResponse {
+        choices: vec![ChatChoice {
+            message: ChatMessage {
+                role: "assistant".into(),
+                content: None,
+                reasoning_content: None,
+                tool_calls: Some(vec![json!({
+                    "id": "call_patch_input",
+                    "type": "function",
+                    "function": {
+                        "name": "apply_patch",
+                        "arguments": json!({"input": patch}).to_string()
+                    }
+                })]),
+                tool_call_id: None,
+                name: None,
+            },
+        }],
+        usage: None,
+    };
+    let custom_tools = custom_tool_map(&tools);
+    let (response, _) = from_chat_response_with_tool_maps(
+        "resp_37_input".into(),
+        "mock-model",
+        chat,
+        &Default::default(),
+        &custom_tools,
+    );
+    let item = &response.output[0];
+    assert_eq!(item["type"], "custom_tool_call");
+    assert_eq!(item["input"], patch);
+
+    // The next-turn replay wraps the raw input back using the declared field.
+    let req: ResponsesRequest = serde_json::from_value(json!({
+        "model": "mock-model",
+        "input": [
+            {
+                "type": "custom_tool_call",
+                "call_id": "call_patch_input",
+                "name": "apply_patch",
+                "input": patch
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_patch_input",
+                "output": "Done"
+            }
+        ],
+        "tools": tools,
+        "stream": false
+    }))
+    .unwrap();
+    let chat_req = to_chat_request(&req, Vec::new(), &SessionStore::new());
+    let assistant = chat_req
+        .messages
+        .iter()
+        .find(|msg| msg.tool_calls.is_some())
+        .expect("assistant tool call message");
+    let args = assistant.tool_calls.as_ref().unwrap()[0]["function"]["arguments"]
+        .as_str()
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<Value>(args).unwrap(),
+        json!({"input": patch})
+    );
+}
+
+#[test]
+fn dsml_leak_blocking_response_heals_into_function_call() {
+    // DeepSeek V4 intermittently returns tool calls as raw DSML markup in
+    // content instead of structured tool_calls. The relay must heal them.
+    let dsml = "<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"shell\">\n<｜DSML｜parameter name=\"command\" string=\"true\">Get-Content 'D:\\2026年\\病毒学\\data.csv' -Encoding UTF8 -TotalCount 5</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>";
+    let chat = ChatResponse {
+        choices: vec![ChatChoice {
+            message: ChatMessage {
+                role: "assistant".into(),
+                content: Some(Value::String(format!("我来逐步完成这个任务。\n{dsml}"))),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: None,
+                name: None,
+            },
+        }],
+        usage: None,
+    };
+    let (response, history) = from_chat_response_with_tool_map(
+        "resp_dsml".into(),
+        "deepseek-v4-pro",
+        chat,
+        &Default::default(),
+    );
+
+    assert_eq!(response.output[0]["type"], "message");
+    assert_eq!(
+        response.output[0]["content"][0]["text"],
+        "我来逐步完成这个任务。"
+    );
+    let call = &response.output[1];
+    assert_eq!(call["type"], "function_call");
+    assert_eq!(call["name"], "shell");
+    let args: Value = serde_json::from_str(call["arguments"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        args["command"],
+        "Get-Content 'D:\\2026年\\病毒学\\data.csv' -Encoding UTF8 -TotalCount 5"
+    );
+
+    // Session history must store the healed message, not the raw markup.
+    assert_eq!(history[0].text_content(), "我来逐步完成这个任务。");
+    assert_eq!(history[0].tool_calls.as_ref().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn dsml_leak_streaming_heals_into_function_call_events() {
+    // Leaked DSML arrives as ordinary content deltas, with markers split
+    // across chunk boundaries. The relay must withhold the markup from
+    // output_text deltas and emit healed function_call events instead.
+    let dsml_sse = sse_from_chunks(vec![
+        json!({"choices": [{"delta": {"content": "我来读取文件。"}}]}),
+        json!({"choices": [{"delta": {"content": "<｜DS"}}]}),
+        json!({"choices": [{"delta": {"content": "ML｜tool_calls>\n<｜DSML｜invoke name=\"shell\">\n"}}]}),
+        json!({"choices": [{"delta": {"content": "<｜DSML｜parameter name=\"command\" string=\"true\">ls -la</｜DSML｜parameter>\n</｜DSML｜invoke>\n"}}]}),
+        json!({"choices": [{"delta": {"content": "</｜DSML｜tool_calls>"}}]}),
+        json!({"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}),
+    ]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![dsml_sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "input": "读取文件",
+            "tools": [{"type": "function", "name": "shell", "parameters": {"type": "object"}}],
+            "stream": true
+        }),
+    )
+    .await;
+
+    // No DSML markup may leak into visible text deltas.
+    for (event, data) in &events {
+        if event == "response.output_text.delta" {
+            let delta = data["delta"].as_str().unwrap();
+            assert!(!delta.contains("DSML"), "DSML leaked into delta: {delta}");
+        }
+    }
+
+    let fc_done = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.done" && data["item"]["type"] == "function_call"
+        })
+        .map(|(_, data)| &data["item"])
+        .expect("healed function_call done item");
+    assert_eq!(fc_done["name"], "shell");
+    let args: Value = serde_json::from_str(fc_done["arguments"].as_str().unwrap()).unwrap();
+    assert_eq!(args["command"], "ls -la");
+    assert!(fc_done["call_id"]
+        .as_str()
+        .unwrap()
+        .starts_with("call_dsml_"));
+
+    let completed = events
+        .iter()
+        .find_map(|(event, data)| (event == "response.completed").then_some(data))
+        .expect("response.completed");
+    let output = completed["response"]["output"].as_array().unwrap();
+    let message = output
+        .iter()
+        .find(|item| item["type"] == "message")
+        .unwrap();
+    assert_eq!(
+        message["content"][0]["text"], "我来读取文件。",
+        "final message text must not contain DSML markup"
+    );
+    assert!(
+        output.iter().any(|item| item["type"] == "function_call"),
+        "completed output must include the healed function_call"
+    );
+}
+
+#[tokio::test]
+async fn dsml_heal_quirk_can_be_disabled_via_env() {
+    // CODEX_RELAY_DISABLE_QUIRKS is the per-quirk kill switch: with dsml_heal
+    // disabled the markup must pass through as plain text, untouched.
+    let dsml_sse = sse_from_chunks(vec![
+        json!({"choices": [{"delta": {"content": "<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"shell\">\n<｜DSML｜parameter name=\"command\" string=\"true\">ls</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>"}}]}),
+        json!({"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}),
+    ]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![dsml_sse]).await;
+    let relay = Relay::spawn_with_env(
+        &format!("http://127.0.0.1:{upstream_port}/v1"),
+        &[("CODEX_RELAY_DISABLE_QUIRKS", "dsml_heal")],
+    );
+
+    let events = post_stream_events(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "input": "读取文件",
+            "tools": [{"type": "function", "name": "shell", "parameters": {"type": "object"}}],
+            "stream": true
+        }),
+    )
+    .await;
+
+    assert!(
+        !events
+            .iter()
+            .any(|(event, data)| event == "response.output_item.done"
+                && data["item"]["type"] == "function_call"),
+        "disabled quirk must not synthesize function_call items"
+    );
+    let text: String = events
+        .iter()
+        .filter(|(event, _)| event == "response.output_text.delta")
+        .map(|(_, data)| data["delta"].as_str().unwrap())
+        .collect();
+    assert!(
+        text.contains("<｜DSML｜tool_calls>"),
+        "markup should pass through untouched when the quirk is disabled"
+    );
+}
+
+#[test]
 fn blocking_response_usage_includes_cached_tokens() {
     let chat = ChatResponse {
         choices: vec![ChatChoice {


### PR DESCRIPTION
Fixes #37 and adds healing for DeepSeek V4's leaked DSML tool-call markup, plus a unified registry for platform-specific quirks.

## 1. apply_patch → custom_tool_call detection by name (fixes #37)

PR #38 only treated apply_patch as a custom tool when the request declared `"type": "custom"`, but real Codex CLI declares it as a plain `function` tool in the affected configurations (see the follow-up reports in #37). Upstream codex-rs confirms the current `ApplyPatchHandler` only accepts `ToolPayload::Custom` — a `function_call` item is rejected as an incompatible payload — while historical versions accepted both, so always emitting `custom_tool_call` is safe for old and new Codex CLI.

- `custom_tool_map` now also matches a function-declared tool named `apply_patch`, deriving the argument field from the declared schema: `patch` (current reports) or `input` (historical `create_apply_patch_json_tool` variant), with `patch` as fallback.
- Replayed `custom_tool_call` input items wrap their raw input using the same request-scoped argument field instead of a hardcoded `patch`.
- The declared function schema still passes through to the upstream Chat Completions request unchanged.

## 2. DSML tool-call healing (quirk `dsml_heal`)

DeepSeek V4 intermittently leaks its internal DSML tool-call markup into assistant text content instead of returning structured `tool_calls` — especially with `tool_choice=auto` + streaming, and near-always when a parameter value contains newlines (vllm-project/vllm#40801 and multiple agent projects report the same). Codex then sees plain text, no tool runs, and the turn silently stalls:

```
<｜DSML｜tool_calls>
<｜DSML｜invoke name="shell">
<｜DSML｜parameter name="command" string="true">Get-Content 'D:\...csv' -Encoding UTF8 -TotalCount 5</｜DSML｜parameter>
</｜DSML｜invoke>
</｜DSML｜tool_calls>
```

New `src/dsml.rs` heals this in both paths:

- **Blocking**: leaked markup is parsed into structured tool calls and stripped from the visible text before translation; healed calls flow through the existing pipeline (so a healed `apply_patch` also becomes a `custom_tool_call`, combining with fix 1).
- **Streaming**: an incremental filter withholds text that could be a DSML marker (markers split across chunk boundaries are handled), buffers the markup, and merges the healed calls into the accumulated tool calls at end of stream.
- Parameter values are treated as opaque until the closing tag (multiline-safe); `string="false"` values are parsed as JSON scalars; unparseable markup passes through as raw text so nothing is ever lost.
- Session history stores the healed message, so markup cannot contaminate later turns.

The `｜` (U+FF5C) delimiters are DeepSeek-internal tokens that never appear in legitimate output, so healing is detection-gated rather than model-name-gated — the same leak occurs through NVIDIA NIM, Ollama Cloud, and self-hosted vLLM under many model names.

## 3. Platform quirk registry (`src/quirks.rs`)

Provider-specific workarounds are now managed uniformly with a documented lifecycle:

| Quirk | Kind | Behavior |
|---|---|---|
| `glm_thinking` | request-shaping | existing GLM `thinking: enabled` gate (issue #26), moved into the registry |
| `dsml_heal` | response-healing | this PR |
| `missing_done` | response-healing | existing tolerance for streams without `[DONE]` (issue #31), now registered |

- Response healers log `quirk <name> fired` warnings as removal telemetry: once the provider fixes the underlying bug the quirk stops firing, and sustained silence makes it a deletion candidate (removal criteria are documented per quirk in `quirks.rs`).
- `CODEX_RELAY_DISABLE_QUIRKS=dsml_heal,...` disables any quirk immediately without waiting for a relay release. Defaults are unchanged: all quirks remain enabled.

## Validation

- `cargo test`: 197 tests pass (12 live external-provider tests remain ignored)
- `cargo clippy --all-targets`: no new warnings
- New regression coverage: function-declared apply_patch (both `patch` and `input` schemas, response + replay), DSML healing blocking + streaming (markers split across chunks; no markup in any `output_text.delta`; healed `function_call` in `response.completed`), quirk kill switch end-to-end (`CODEX_RELAY_DISABLE_QUIRKS=dsml_heal` passes markup through untouched)

Happy to split this into separate PRs if preferred.
