### PR TITLE
fix: recover dropped [DONE] event and route leaked <think> markup to reasoning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod dsml;
 pub mod quirks;
 pub mod session;
 pub mod stream;
+pub mod think;
 pub mod translate;
 pub mod types;
 pub mod upstream_request;

--- a/src/main.rs
+++ b/src/main.rs
@@ -808,22 +808,22 @@ async fn handle_blocking(
                     "← upstream function_calls={}",
                     summarize_debug_names(chat_response_tool_call_debug_names(&chat_resp))
                 );
-                let assistant_msg = chat_resp
-                    .choices
-                    .first()
-                    .map(|c| c.message.clone())
-                    .unwrap_or_else(|| ChatMessage {
-                        role: "assistant".into(),
-                        content: Some(serde_json::Value::String(String::new())),
-                        reasoning_content: None,
-                        tool_calls: None,
-                        tool_call_id: None,
-                        name: None,
-                    });
-
-                let mut full_history = chat_req.messages.clone();
-                full_history.push(assistant_msg);
                 let response_id = state.sessions.new_id();
+                let (resp, assistant_messages) =
+                    if namespace_tools.is_empty() && custom_tools.is_empty() {
+                        translate::from_chat_response(response_id.clone(), &model, chat_resp)
+                    } else {
+                        translate::from_chat_response_with_tool_maps(
+                            response_id.clone(),
+                            &model,
+                            chat_resp,
+                            &namespace_tools,
+                            &custom_tools,
+                        )
+                    };
+
+                let mut full_history = chat_req.messages;
+                full_history.extend(assistant_messages);
                 if let Some(corpus) = &state.corpus {
                     corpus.record_turn(
                         previous_response_id.as_deref(),
@@ -832,19 +832,7 @@ async fn handle_blocking(
                         &full_history,
                     );
                 }
-                state.sessions.save_with_id(response_id.clone(), full_history);
-
-                let (resp, _) = if namespace_tools.is_empty() && custom_tools.is_empty() {
-                    translate::from_chat_response(response_id, &model, chat_resp)
-                } else {
-                    translate::from_chat_response_with_tool_maps(
-                        response_id,
-                        &model,
-                        chat_resp,
-                        &namespace_tools,
-                        &custom_tools,
-                    )
-                };
+                state.sessions.save_with_id(response_id, full_history);
                 Json(resp).into_response()
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod dsml;
 mod quirks;
 mod session;
 mod stream;
+mod think;
 mod translate;
 mod types;
 mod upstream_request;

--- a/src/quirks.rs
+++ b/src/quirks.rs
@@ -34,12 +34,13 @@
 //! |----------------|-------|-------------------------------------------|-------------|
 //! | `glm_thinking` | A     | model name looks like GLM/Zhipu           | GLM emits reasoning_content without the explicit `thinking` switch (issue #26) |
 //! | `dsml_heal`    | B     | leaked `<｜DSML｜` markup in text content  | DeepSeek V4 stops leaking DSML (vllm-project/vllm#40801) and telemetry shows no firings for ~a month |
-//! | `missing_done` | B     | SSE stream closes cleanly without `[DONE]`| providers (e.g. synthetic.new) terminate streams spec-compliantly (issue #31) |
+//! | `missing_done` | B     | SSE stream closes cleanly without `[DONE]`| providers terminate streams spec-compliantly (issue #31) |
+//! | `think_tags`   | B     | `<think>` markup leaked into text content  | providers deploy reasoning models with a matching vLLM `--reasoning-parser` so thinking arrives in `reasoning_content` |
 
 use std::collections::HashSet;
 
 /// Names of all registered quirks, for validation and documentation.
-pub const QUIRK_NAMES: &[&str] = &["glm_thinking", "dsml_heal", "missing_done"];
+pub const QUIRK_NAMES: &[&str] = &["glm_thinking", "dsml_heal", "missing_done", "think_tags"];
 
 /// Whether a quirk is enabled, honoring the `CODEX_RELAY_DISABLE_QUIRKS`
 /// kill switch (comma-separated quirk names, case-insensitive).

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -15,6 +15,7 @@ use crate::{
     corpus::CorpusRecorder,
     dsml::{synthesize_call_id, DsmlStreamFilter},
     session::SessionStore,
+    think::ThinkStreamFilter,
     translate::{
         custom_tool_input, response_function_name_for_responses, CustomToolMap, NamespaceToolMap,
     },
@@ -139,6 +140,9 @@ pub fn translate_stream(
         // and heals it into structured tool calls at end of stream.
         // Quirk `dsml_heal`, see quirks.rs.
         let mut dsml_filter = DsmlStreamFilter::new(crate::quirks::quirk_enabled("dsml_heal"));
+        // Splits leaked `<think>` markup out of text content and onto the
+        // reasoning channel. Quirk `think_tags`, see quirks.rs.
+        let mut think_filter = ThinkStreamFilter::new(crate::quirks::quirk_enabled("think_tags"));
         let mut reasoning_chunks: usize = 0;
         let mut tool_calls: BTreeMap<usize, ToolCallAccum> = BTreeMap::new();
         let mut reasoning_output_index: Option<usize> = None;
@@ -146,8 +150,27 @@ pub fn translate_stream(
         let mut next_output_index: usize = 0;
         let mut stream_done = false;
         let mut stream_err = false;
+        // The upstream's own end-of-turn signal. Distinguishes "provider closed
+        // without [DONE]" (safe to complete) from "connection died mid-turn"
+        // (must not be completed).
+        let mut finish_reason: Option<String> = None;
         let mut stream_usage: Option<ChatUsage> = None;
-        let mut source = upstream.bytes_stream().eventsource();
+        // synthetic.new terminates the stream with `\n\ndata: [DONE]` and no
+        // trailing newline. eventsource-stream follows the SSE spec and
+        // discards a pending event that was never terminated by a blank line,
+        // so `[DONE]` is silently lost and every turn falls through to the
+        // `missing_done` quirk. Appending a blank line flushes it. Against
+        // spec-compliant providers this is a no-op: a blank line with an empty
+        // data buffer dispatches no event.
+        let mut source = upstream
+            .bytes_stream()
+            .chain(futures_util::stream::once(std::future::ready(Ok::<
+                _,
+                reqwest::Error,
+            >(
+                bytes::Bytes::from_static(b"\n\n"),
+            ))))
+            .eventsource();
 
         while let Some(ev) = source.next().await {
             match ev {
@@ -170,10 +193,25 @@ pub fn translate_stream(
                                 stream_usage = usage;
                             }
                             for choice in &choices {
+                                if let Some(fr) = &choice.finish_reason {
+                                    finish_reason = Some(fr.clone());
+                                }
+                                // Split leaked `<think>` markup out of the text
+                                // content before anything else looks at it, so
+                                // thinking reaches the reasoning channel and
+                                // never enters accumulated_text or history.
+                                let think = think_filter
+                                    .push(choice.delta.content.as_deref().unwrap_or(""));
                                 // Reasoning/thinking content (kimi-k2.6, GLM, etc.).
                                 // Field name varies by provider (reasoning_content
                                 // vs reasoning) — normalized via reasoning_text().
-                                if let Some(rc) = choice.delta.reasoning_text() {
+                                {
+                                    let reasoning_delta = match choice.delta.reasoning_text() {
+                                        Some(native) if think.reasoning.is_empty() => native.to_string(),
+                                        Some(native) => format!("{native}{}", think.reasoning),
+                                        None => think.reasoning.clone(),
+                                    };
+                                    let rc = reasoning_delta.as_str();
                                     if !rc.is_empty() {
                                         reasoning_chunks += 1;
                                         let output_index = match reasoning_output_index {
@@ -210,7 +248,7 @@ pub fn translate_stream(
                                 }
 
                                 // Text content, filtered for leaked DSML markup.
-                                let content = dsml_filter.push(choice.delta.content.as_deref().unwrap_or(""));
+                                let content = dsml_filter.push(&think.text);
                                 if !content.is_empty() {
                                     let output_index = match message_output_index {
                                         Some(idx) => idx,
@@ -277,10 +315,52 @@ pub fn translate_stream(
             }
         }
 
+        // Flush the think filter first: an unterminated `<think>` block stays
+        // on the reasoning channel rather than leaking into visible text.
+        let think_fired = think_filter.fired();
+        let think_tail = think_filter.finish();
+        if think_fired {
+            warn!("quirk think_tags fired: split leaked <think> markup out of streamed text");
+        }
+        if !think_tail.reasoning.is_empty() {
+            let output_index = match reasoning_output_index {
+                Some(idx) => idx,
+                None => {
+                    let idx = next_output_index;
+                    next_output_index += 1;
+                    reasoning_output_index = Some(idx);
+                    yield Ok(Event::default()
+                        .event("response.output_item.added")
+                        .data(json!({
+                            "type": "response.output_item.added",
+                            "output_index": idx,
+                            "item": {
+                                "type": "reasoning",
+                                "id": &reasoning_item_id,
+                                "summary": [{"type": "summary_text", "text": ""}]
+                            }
+                        }).to_string()));
+                    idx
+                }
+            };
+            accumulated_reasoning.push_str(&think_tail.reasoning);
+            yield Ok(Event::default()
+                .event("response.reasoning_summary_text.delta")
+                .data(json!({
+                    "type": "response.reasoning_summary_text.delta",
+                    "item_id": &reasoning_item_id,
+                    "output_index": output_index,
+                    "summary_index": 0,
+                    "delta": &think_tail.reasoning
+                }).to_string()));
+        }
+        let think_leftover = dsml_filter.push(&think_tail.text);
+
         // Flush the DSML filter: healed tool calls join the accumulated
         // tool_calls (and are emitted as function_call/custom_tool_call items
         // below); any remaining visible text is emitted as a final delta.
-        let (dsml_leftover, dsml_calls) = dsml_filter.finish();
+        let (dsml_tail, dsml_calls) = dsml_filter.finish();
+        let dsml_leftover = format!("{think_leftover}{dsml_tail}");
         if !dsml_leftover.is_empty() {
             let output_index = match message_output_index {
                 Some(idx) => idx,
@@ -469,19 +549,23 @@ pub fn translate_stream(
             fc_items.push((output_index, done_item));
         }
 
-        // Some OpenAI-compatible providers (e.g. synthetic.new) close the SSE
-        // stream cleanly without emitting a terminating `[DONE]` line. If the
-        // stream ended without an error and we already received a full turn
-        // (text and/or tool calls), treat it as complete so the response is
-        // persisted and `response.completed` is emitted. A mid-stream error
-        // (stream_err) still discards the partial turn.
-        if !stream_done
-            && !stream_err
-            && (!accumulated_text.is_empty() || !tool_calls.is_empty())
-            && crate::quirks::quirk_enabled("missing_done")
-        {
-            warn!("quirk missing_done fired: stream ended without [DONE] but content was received — treating as complete");
-            stream_done = true;
+        // Some OpenAI-compatible providers close the SSE stream without a
+        // terminating `[DONE]` line. The upstream's own end-of-turn signal is
+        // `finish_reason`, not "we have some content": completing on content
+        // alone silently promotes a connection that died mid-generation into a
+        // successful turn, which then gets persisted to history. A mid-stream
+        // error (stream_err) still discards the partial turn.
+        if !stream_done && !stream_err && crate::quirks::quirk_enabled("missing_done") {
+            match finish_reason.as_deref() {
+                Some(reason) => {
+                    warn!("quirk missing_done fired: stream ended without [DONE] (finish_reason={reason}) — treating as complete");
+                    stream_done = true;
+                }
+                None if !accumulated_text.is_empty() || !tool_calls.is_empty() => {
+                    warn!("stream ended without [DONE] and without finish_reason — turn was truncated, discarding");
+                }
+                None => {}
+            }
         }
 
         if stream_done {

--- a/src/think.rs
+++ b/src/think.rs
@@ -1,0 +1,328 @@
+//! Healing for reasoning models that leak `<think>` markup into text content.
+//!
+//! Thinking models are supposed to expose chain of thought in a separate
+//! `reasoning_content` (or `reasoning`) field. Several vLLM deployments —
+//! including ones behind synthetic.new — run without a matching
+//! `--reasoning-parser`, so the raw chat-template markup lands in the
+//! assistant `content` instead:
+//!
+//! ```text
+//! <think>The user said hi. I should greet them back.</think>Hello!
+//! ```
+//!
+//! Codex then renders the chain of thought as assistant text, and the markup
+//! is persisted into history and replayed upstream, where it teaches the model
+//! to keep producing it. This module splits the markup back out so thinking is
+//! emitted on the reasoning channel (`response.reasoning_summary_text.delta`)
+//! and never reaches the visible message.
+//!
+//! Some chat templates pre-fill the opening `<think>` into the prompt, so the
+//! model only ever emits the *closing* tag. A `</think>` seen before any
+//! visible text has been emitted is therefore treated as terminating an
+//! implicit reasoning block.
+
+use crate::types::ChatMessage;
+
+/// Opening markers. `◁think▷` is Kimi's variant.
+const OPEN_TAGS: &[&str] = &["<thinking>", "<think>", "◁think▷"];
+/// Closing markers, matching [`OPEN_TAGS`].
+const CLOSE_TAGS: &[&str] = &["</thinking>", "</think>", "◁/think▷"];
+
+/// The two channels a content delta can be split across.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ThinkSplit {
+    /// Text that belongs on the reasoning channel.
+    pub reasoning: String,
+    /// Text that belongs in the visible assistant message.
+    pub text: String,
+}
+
+impl ThinkSplit {
+    fn is_empty(&self) -> bool {
+        self.reasoning.is_empty() && self.text.is_empty()
+    }
+}
+
+/// Incremental `<think>` splitter for streamed text content.
+///
+/// Feed content deltas through [`ThinkStreamFilter::push`]; it returns the
+/// reasoning and visible text that are safe to emit now. Text that could be
+/// (part of) a tag is withheld until the next delta disambiguates it, so a tag
+/// split across SSE chunks (`"<thi"` then `"nk>"`) is still recognized.
+#[derive(Debug)]
+pub struct ThinkStreamFilter {
+    pending: String,
+    in_think: bool,
+    emitted_text: bool,
+    fired: bool,
+    enabled: bool,
+}
+
+impl Default for ThinkStreamFilter {
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
+
+impl ThinkStreamFilter {
+    /// A filter that splits when `enabled`, or passes all text through
+    /// untouched as visible text when the `think_tags` quirk is disabled.
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            pending: String::new(),
+            in_think: false,
+            emitted_text: false,
+            fired: false,
+            enabled,
+        }
+    }
+
+    /// Whether any think markup was actually seen (quirk telemetry).
+    pub fn fired(&self) -> bool {
+        self.fired
+    }
+
+    /// Append a content delta; returns the portions safe to emit now.
+    pub fn push(&mut self, delta: &str) -> ThinkSplit {
+        let mut out = ThinkSplit::default();
+        if !self.enabled {
+            out.text.push_str(delta);
+            return out;
+        }
+        self.pending.push_str(delta);
+        loop {
+            if self.in_think {
+                if let Some((at, tag)) = first_tag(&self.pending, CLOSE_TAGS) {
+                    out.reasoning.push_str(&self.pending[..at]);
+                    self.pending.drain(..at + tag.len());
+                    self.in_think = false;
+                    continue;
+                }
+                let keep = self.pending.len() - longest_tag_prefix_suffix(&self.pending, CLOSE_TAGS);
+                out.reasoning.push_str(&self.pending[..keep]);
+                self.pending.drain(..keep);
+                return out;
+            }
+
+            let open = first_tag(&self.pending, OPEN_TAGS);
+            let close = if self.emitted_text {
+                None
+            } else {
+                first_tag(&self.pending, CLOSE_TAGS)
+            };
+
+            match (open, close) {
+                (Some((at, tag)), close) if close.is_none_or(|(c, _)| at < c) => {
+                    self.emit_text(&mut out, at);
+                    self.pending.drain(..at + tag.len());
+                    self.in_think = true;
+                    self.fired = true;
+                }
+                // Template pre-filled the opening tag: everything up to the
+                // stray `</think>` is reasoning.
+                (_, Some((at, tag))) => {
+                    out.reasoning.push_str(&self.pending[..at]);
+                    self.pending.drain(..at + tag.len());
+                    self.fired = true;
+                }
+                (_, None) => {
+                    let keep = self.pending.len() - longest_tag_prefix_suffix_any(&self.pending);
+                    self.emit_text(&mut out, keep);
+                    self.pending.drain(..keep);
+                    return out;
+                }
+            }
+        }
+    }
+
+    /// Consume the filter at end of stream, returning anything still withheld.
+    /// An unterminated `<think>` block is treated as reasoning, not text.
+    pub fn finish(mut self) -> ThinkSplit {
+        let mut out = ThinkSplit::default();
+        let rest = std::mem::take(&mut self.pending);
+        if self.in_think {
+            out.reasoning = rest;
+        } else if self.emitted_text {
+            out.text = rest;
+        } else {
+            out.text = rest.trim_start().to_string();
+        }
+        out
+    }
+
+    /// Emit `self.pending[..upto]` as visible text, trimming the leading
+    /// whitespace that chat templates leave after a closing tag.
+    fn emit_text(&mut self, out: &mut ThinkSplit, upto: usize) {
+        let chunk = if self.emitted_text {
+            &self.pending[..upto]
+        } else {
+            self.pending[..upto].trim_start()
+        };
+        if !chunk.is_empty() {
+            self.emitted_text = true;
+            out.text.push_str(chunk);
+        }
+    }
+}
+
+/// Heal a blocking Chat Completions assistant message in place: move leaked
+/// think markup out of the visible content and into `reasoning_content`.
+pub fn heal_chat_message(message: &mut ChatMessage) {
+    let text = message.text_content().to_string();
+    if !contains_think_markup(&text) {
+        return;
+    }
+    let mut filter = ThinkStreamFilter::new(true);
+    let mut split = filter.push(&text);
+    let fired = filter.fired();
+    let tail = filter.finish();
+    split.reasoning.push_str(&tail.reasoning);
+    split.text.push_str(&tail.text);
+    if !fired || split.is_empty() {
+        return;
+    }
+    tracing::warn!("quirk think_tags fired: healed leaked <think> markup from blocking response");
+    message.content = if split.text.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::String(split.text))
+    };
+    if !split.reasoning.is_empty() {
+        match &mut message.reasoning_content {
+            Some(existing) => existing.push_str(&split.reasoning),
+            slot @ None => *slot = Some(split.reasoning),
+        }
+    }
+}
+
+/// Whether `text` contains any think marker at all (cheap pre-check).
+pub fn contains_think_markup(text: &str) -> bool {
+    OPEN_TAGS
+        .iter()
+        .chain(CLOSE_TAGS)
+        .any(|tag| text.contains(tag))
+}
+
+/// Byte offset and matched tag of the earliest tag in `text`, preferring the
+/// longest tag when several start at the same offset.
+fn first_tag<'a>(text: &str, tags: &[&'a str]) -> Option<(usize, &'a str)> {
+    tags.iter()
+        .filter_map(|tag| text.find(tag).map(|at| (at, *tag)))
+        .min_by_key(|(at, tag)| (*at, std::cmp::Reverse(tag.len())))
+}
+
+/// Length in bytes of the longest suffix of `text` that is a proper prefix of
+/// any tag in `tags`.
+fn longest_tag_prefix_suffix(text: &str, tags: &[&str]) -> usize {
+    let mut best = 0;
+    for tag in tags {
+        for (i, _) in tag.char_indices().skip(1) {
+            if i > best && text.ends_with(&tag[..i]) {
+                best = i;
+            }
+        }
+    }
+    best
+}
+
+fn longest_tag_prefix_suffix_any(text: &str) -> usize {
+    longest_tag_prefix_suffix(text, OPEN_TAGS).max(longest_tag_prefix_suffix(text, CLOSE_TAGS))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive a filter over a sequence of deltas, returning the joined channels.
+    fn run(deltas: &[&str]) -> ThinkSplit {
+        let mut filter = ThinkStreamFilter::new(true);
+        let mut all = ThinkSplit::default();
+        for delta in deltas {
+            let split = filter.push(delta);
+            all.reasoning.push_str(&split.reasoning);
+            all.text.push_str(&split.text);
+        }
+        let tail = filter.finish();
+        all.reasoning.push_str(&tail.reasoning);
+        all.text.push_str(&tail.text);
+        all
+    }
+
+    #[test]
+    fn splits_a_complete_think_block() {
+        let out = run(&["<think>musing</think>\n\nHello!"]);
+        assert_eq!(out.reasoning, "musing");
+        assert_eq!(out.text, "Hello!");
+    }
+
+    #[test]
+    fn recognizes_tags_split_across_deltas() {
+        let out = run(&["<thi", "nk>mus", "ing</th", "ink>Hi"]);
+        assert_eq!(out.reasoning, "musing");
+        assert_eq!(out.text, "Hi");
+    }
+
+    #[test]
+    fn treats_stray_close_tag_as_implicit_open() {
+        // Template pre-filled `<think>` into the prompt.
+        let out = run(&["musing", "</think>", "Hi"]);
+        assert_eq!(out.reasoning, "musing");
+        assert_eq!(out.text, "Hi");
+    }
+
+    #[test]
+    fn passes_plain_text_through_untouched() {
+        let out = run(&["Hello", " world"]);
+        assert_eq!(out.reasoning, "");
+        assert_eq!(out.text, "Hello world");
+        assert!(!ThinkStreamFilter::new(true).fired());
+    }
+
+    #[test]
+    fn close_tag_after_visible_text_is_not_reasoning() {
+        // Once real text has been emitted a bare `</think>` is just text; only
+        // a matched `<think>…</think>` pair splits.
+        let out = run(&["see the </think> tag"]);
+        assert_eq!(out.reasoning, "");
+        assert_eq!(out.text, "see the </think> tag");
+    }
+
+    #[test]
+    fn unterminated_think_block_stays_reasoning() {
+        let out = run(&["<think>cut off mid-thought"]);
+        assert_eq!(out.reasoning, "cut off mid-thought");
+        assert_eq!(out.text, "");
+    }
+
+    #[test]
+    fn kimi_markers_are_recognized() {
+        let out = run(&["◁think▷musing◁/think▷Hi"]);
+        assert_eq!(out.reasoning, "musing");
+        assert_eq!(out.text, "Hi");
+    }
+
+    #[test]
+    fn disabled_filter_passes_markup_through() {
+        let mut filter = ThinkStreamFilter::new(false);
+        let out = filter.push("<think>musing</think>Hi");
+        assert_eq!(out.reasoning, "");
+        assert_eq!(out.text, "<think>musing</think>Hi");
+    }
+
+    #[test]
+    fn heals_blocking_message() {
+        let mut message = ChatMessage {
+            role: "assistant".into(),
+            content: Some(serde_json::Value::String(
+                "<think>musing</think>Hello!".into(),
+            )),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        };
+        heal_chat_message(&mut message);
+        assert_eq!(message.text_content(), "Hello!");
+        assert_eq!(message.reasoning_content.as_deref(), Some("musing"));
+    }
+}

--- a/src/think.rs
+++ b/src/think.rs
@@ -16,10 +16,10 @@
 //! emitted on the reasoning channel (`response.reasoning_summary_text.delta`)
 //! and never reaches the visible message.
 //!
-//! Some chat templates pre-fill the opening `<think>` into the prompt, so the
-//! model only ever emits the *closing* tag. A `</think>` seen before any
-//! visible text has been emitted is therefore treated as terminating an
-//! implicit reasoning block.
+//! Some chat templates pre-fill the opening `<think>` into the prompt, so a
+//! blocking response may contain only the closing tag. Streaming repair only
+//! recognizes explicit opening tags because interpreting a later bare closing
+//! tag would otherwise depend on arbitrary SSE chunk boundaries.
 
 use crate::types::ChatMessage;
 
@@ -37,12 +37,6 @@ pub struct ThinkSplit {
     pub text: String,
 }
 
-impl ThinkSplit {
-    fn is_empty(&self) -> bool {
-        self.reasoning.is_empty() && self.text.is_empty()
-    }
-}
-
 /// Incremental `<think>` splitter for streamed text content.
 ///
 /// Feed content deltas through [`ThinkStreamFilter::push`]; it returns the
@@ -54,6 +48,7 @@ pub struct ThinkStreamFilter {
     pending: String,
     in_think: bool,
     emitted_text: bool,
+    trim_after_close: bool,
     fired: bool,
     enabled: bool,
 }
@@ -72,6 +67,7 @@ impl ThinkStreamFilter {
             pending: String::new(),
             in_think: false,
             emitted_text: false,
+            trim_after_close: false,
             fired: false,
             enabled,
         }
@@ -96,37 +92,43 @@ impl ThinkStreamFilter {
                     out.reasoning.push_str(&self.pending[..at]);
                     self.pending.drain(..at + tag.len());
                     self.in_think = false;
+                    self.trim_after_close = !self.emitted_text;
                     continue;
                 }
-                let keep = self.pending.len() - longest_tag_prefix_suffix(&self.pending, CLOSE_TAGS);
+                let keep =
+                    self.pending.len() - longest_tag_prefix_suffix(&self.pending, CLOSE_TAGS);
                 out.reasoning.push_str(&self.pending[..keep]);
                 self.pending.drain(..keep);
                 return out;
             }
 
-            let open = first_tag(&self.pending, OPEN_TAGS);
-            let close = if self.emitted_text {
-                None
-            } else {
-                first_tag(&self.pending, CLOSE_TAGS)
-            };
+            if self.trim_after_close {
+                let first_non_whitespace = self
+                    .pending
+                    .char_indices()
+                    .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index));
+                match first_non_whitespace {
+                    Some(index) => {
+                        self.pending.drain(..index);
+                        self.trim_after_close = false;
+                    }
+                    None => {
+                        self.pending.clear();
+                        return out;
+                    }
+                }
+            }
 
-            match (open, close) {
-                (Some((at, tag)), close) if close.is_none_or(|(c, _)| at < c) => {
+            match first_tag(&self.pending, OPEN_TAGS) {
+                Some((at, tag)) => {
                     self.emit_text(&mut out, at);
                     self.pending.drain(..at + tag.len());
                     self.in_think = true;
                     self.fired = true;
                 }
-                // Template pre-filled the opening tag: everything up to the
-                // stray `</think>` is reasoning.
-                (_, Some((at, tag))) => {
-                    out.reasoning.push_str(&self.pending[..at]);
-                    self.pending.drain(..at + tag.len());
-                    self.fired = true;
-                }
-                (_, None) => {
-                    let keep = self.pending.len() - longest_tag_prefix_suffix_any(&self.pending);
+                None => {
+                    let keep =
+                        self.pending.len() - longest_tag_prefix_suffix(&self.pending, OPEN_TAGS);
                     self.emit_text(&mut out, keep);
                     self.pending.drain(..keep);
                     return out;
@@ -142,22 +144,19 @@ impl ThinkStreamFilter {
         let rest = std::mem::take(&mut self.pending);
         if self.in_think {
             out.reasoning = rest;
-        } else if self.emitted_text {
-            out.text = rest;
         } else {
-            out.text = rest.trim_start().to_string();
+            out.text = if self.trim_after_close && !self.emitted_text {
+                rest.trim_start().to_string()
+            } else {
+                rest
+            };
         }
         out
     }
 
-    /// Emit `self.pending[..upto]` as visible text, trimming the leading
-    /// whitespace that chat templates leave after a closing tag.
+    /// Emit `self.pending[..upto]` as visible text without changing it.
     fn emit_text(&mut self, out: &mut ThinkSplit, upto: usize) {
-        let chunk = if self.emitted_text {
-            &self.pending[..upto]
-        } else {
-            self.pending[..upto].trim_start()
-        };
+        let chunk = &self.pending[..upto];
         if !chunk.is_empty() {
             self.emitted_text = true;
             out.text.push_str(chunk);
@@ -172,13 +171,27 @@ pub fn heal_chat_message(message: &mut ChatMessage) {
     if !contains_think_markup(&text) {
         return;
     }
-    let mut filter = ThinkStreamFilter::new(true);
-    let mut split = filter.push(&text);
-    let fired = filter.fired();
-    let tail = filter.finish();
-    split.reasoning.push_str(&tail.reasoning);
-    split.text.push_str(&tail.text);
-    if !fired || split.is_empty() {
+    let (split, fired) = if first_tag(&text, OPEN_TAGS).is_none() {
+        match first_tag(&text, CLOSE_TAGS) {
+            Some((at, tag)) => (
+                ThinkSplit {
+                    reasoning: text[..at].to_string(),
+                    text: text[at + tag.len()..].trim_start().to_string(),
+                },
+                true,
+            ),
+            None => (ThinkSplit::default(), false),
+        }
+    } else {
+        let mut filter = ThinkStreamFilter::new(true);
+        let mut split = filter.push(&text);
+        let fired = filter.fired();
+        let tail = filter.finish();
+        split.reasoning.push_str(&tail.reasoning);
+        split.text.push_str(&tail.text);
+        (split, fired)
+    };
+    if !fired {
         return;
     }
     tracing::warn!("quirk think_tags fired: healed leaked <think> markup from blocking response");
@@ -225,10 +238,6 @@ fn longest_tag_prefix_suffix(text: &str, tags: &[&str]) -> usize {
     best
 }
 
-fn longest_tag_prefix_suffix_any(text: &str) -> usize {
-    longest_tag_prefix_suffix(text, OPEN_TAGS).max(longest_tag_prefix_suffix(text, CLOSE_TAGS))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -263,11 +272,11 @@ mod tests {
     }
 
     #[test]
-    fn treats_stray_close_tag_as_implicit_open() {
-        // Template pre-filled `<think>` into the prompt.
+    fn streaming_bare_close_tag_is_chunk_invariant_visible_text() {
         let out = run(&["musing", "</think>", "Hi"]);
-        assert_eq!(out.reasoning, "musing");
-        assert_eq!(out.text, "Hi");
+        assert_eq!(out.reasoning, "");
+        assert_eq!(out.text, "musing</think>Hi");
+        assert_eq!(out, run(&["musing</think>Hi"]));
     }
 
     #[test]
@@ -276,6 +285,26 @@ mod tests {
         assert_eq!(out.reasoning, "");
         assert_eq!(out.text, "Hello world");
         assert!(!ThinkStreamFilter::new(true).fired());
+    }
+
+    #[test]
+    fn preserves_plain_text_leading_whitespace() {
+        assert_eq!(run(&["  indented"]).text, "  indented");
+        assert_eq!(run(&["\n", "  indented"]).text, "\n  indented");
+    }
+
+    #[test]
+    fn explicit_tags_are_chunk_invariant() {
+        let expected = run(&["<think>musing</think>Hi"]);
+        assert_eq!(expected, run(&["<thi", "nk>musing</th", "ink>Hi"]));
+        assert_eq!(expected, run(&["<think>musing</think>", "Hi"]));
+    }
+
+    #[test]
+    fn preserves_whitespace_around_mid_message_think_block() {
+        let out = run(&["prefix ", "<think>x</think>", " suffix"]);
+        assert_eq!(out.reasoning, "x");
+        assert_eq!(out.text, "prefix  suffix");
     }
 
     #[test]
@@ -324,5 +353,34 @@ mod tests {
         heal_chat_message(&mut message);
         assert_eq!(message.text_content(), "Hello!");
         assert_eq!(message.reasoning_content.as_deref(), Some("musing"));
+    }
+
+    #[test]
+    fn heals_blocking_message_with_prefilled_open_tag() {
+        let mut message = ChatMessage {
+            role: "assistant".into(),
+            content: Some("musing</think>Hi".into()),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        };
+        heal_chat_message(&mut message);
+        assert_eq!(message.text_content(), "Hi");
+        assert_eq!(message.reasoning_content.as_deref(), Some("musing"));
+    }
+
+    #[test]
+    fn removes_empty_blocking_think_block() {
+        let mut message = ChatMessage {
+            role: "assistant".into(),
+            content: Some("<think></think>".into()),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        };
+        heal_chat_message(&mut message);
+        assert!(message.content.is_none());
     }
 }

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -573,6 +573,19 @@ pub fn from_chat_response_with_tool_maps(
     tracing::debug!("cache(non-stream): {}", usage.cache_summary());
     let mut output = Vec::new();
 
+    if let Some(reasoning) = choice
+        .message
+        .reasoning_content
+        .as_deref()
+        .filter(|reasoning| !reasoning.is_empty())
+    {
+        output.push(json!({
+            "type": "reasoning",
+            "id": format!("rs_{}", uuid::Uuid::new_v4().simple()),
+            "summary": [{"type": "summary_text", "text": reasoning}]
+        }));
+    }
+
     let text = choice.message.text_content().to_string();
     if !text.is_empty() || choice.message.tool_calls.is_none() {
         output.push(json!({

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -561,6 +561,14 @@ pub fn from_chat_response_with_tool_maps(
         crate::dsml::heal_chat_message(&mut choice.message);
     }
 
+    // Reasoning models served without a vLLM reasoning parser leak `<think>`
+    // markup into the text content instead of `reasoning_content`; split it out
+    // so Codex never renders it and history never replays it.
+    // Quirk `think_tags`, see quirks.rs.
+    if crate::quirks::quirk_enabled("think_tags") {
+        crate::think::heal_chat_message(&mut choice.message);
+    }
+
     let usage = chat.usage.unwrap_or_default();
     tracing::debug!("cache(non-stream): {}", usage.cache_summary());
     let mut output = Vec::new();

--- a/src/types.rs
+++ b/src/types.rs
@@ -205,7 +205,8 @@ pub struct ChatStreamChunk {
 #[derive(Debug, Deserialize)]
 pub struct ChatStreamChoice {
     pub delta: ChatDelta,
-    #[allow(dead_code)]
+    /// Upstream end-of-turn signal. Used by stream.rs to tell a provider that
+    /// merely omitted `[DONE]` from a connection that died mid-generation.
     pub finish_reason: Option<String>,
 }
 

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -569,6 +569,29 @@ async fn chat_handler(State(state): State<MockState>, req: axum::extract::Reques
         .unwrap()
 }
 
+async fn blocking_chat_handler(
+    State(state): State<MockState>,
+    req: axum::extract::Request,
+) -> Response {
+    let bytes = axum::body::to_bytes(req.into_body(), 1_000_000)
+        .await
+        .expect("blocking chat request body");
+    let body: Value = serde_json::from_slice(&bytes).expect("blocking chat request json");
+    state.bodies.lock().unwrap().push(body);
+
+    let response = state
+        .responses
+        .lock()
+        .unwrap()
+        .pop_front()
+        .expect("blocking mock response");
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(response))
+        .unwrap()
+}
+
 async fn delayed_chat_handler(
     State(state): State<MockState>,
     req: axum::extract::Request,
@@ -626,6 +649,17 @@ async fn spawn_mock_upstream_with_responses(
     responses: Vec<String>,
 ) -> (u16, Arc<Mutex<Vec<Value>>>) {
     spawn_mock_upstream_with_chat_handler(responses, chat_handler).await
+}
+
+async fn spawn_blocking_mock_upstream(responses: Vec<Value>) -> (u16, Arc<Mutex<Vec<Value>>>) {
+    spawn_mock_upstream_with_chat_handler(
+        responses
+            .into_iter()
+            .map(|response| response.to_string())
+            .collect(),
+        blocking_chat_handler,
+    )
+    .await
 }
 
 async fn spawn_delayed_mock_upstream() -> (u16, Arc<Mutex<Vec<Value>>>) {
@@ -1123,6 +1157,72 @@ async fn think_tags_leaked_into_content_are_routed_to_reasoning() {
 
     assert_eq!(text, "Hello!", "think markup must not reach visible text");
     assert_eq!(reasoning, "musing");
+}
+
+#[tokio::test]
+async fn blocking_think_tags_are_exposed_and_persisted_as_reasoning() {
+    let (upstream_port, bodies) = spawn_blocking_mock_upstream(vec![
+        json!({
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "<think>secret</think>answer"
+            }}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}
+        }),
+        json!({
+            "choices": [{"message": {"role": "assistant", "content": "next answer"}}],
+            "usage": {"prompt_tokens": 8, "completion_tokens": 2, "total_tokens": 10}
+        }),
+    ])
+    .await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+    let client = reqwest::Client::new();
+
+    let first: Value = client
+        .post(relay.url("/v1/responses"))
+        .json(&json!({
+            "model": "mock-model",
+            "input": "first question",
+            "tools": [],
+            "stream": false
+        }))
+        .send()
+        .await
+        .expect("first blocking request")
+        .error_for_status()
+        .expect("first blocking response status")
+        .json()
+        .await
+        .expect("first blocking response json");
+    assert_eq!(first["output"][0]["type"], "reasoning");
+    assert_eq!(first["output"][0]["summary"][0]["text"], "secret");
+    assert_eq!(first["output"][1]["content"][0]["text"], "answer");
+
+    client
+        .post(relay.url("/v1/responses"))
+        .json(&json!({
+            "model": "mock-model",
+            "previous_response_id": first["id"],
+            "input": "second question",
+            "tools": [],
+            "stream": false
+        }))
+        .send()
+        .await
+        .expect("second blocking request")
+        .error_for_status()
+        .expect("second blocking response status");
+
+    let request_bodies = bodies.lock().unwrap();
+    let replayed = request_bodies[1]["messages"]
+        .as_array()
+        .expect("second request messages")
+        .iter()
+        .find(|message| message["role"] == "assistant")
+        .expect("replayed assistant message");
+    assert_eq!(replayed["content"], "answer");
+    assert_eq!(replayed["reasoning_content"], "secret");
+    assert!(!request_bodies[1].to_string().contains("<think>"));
 }
 
 #[tokio::test]

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -598,6 +598,19 @@ fn sse_from_chunks_without_done(chunks: Vec<Value>) -> String {
     sse
 }
 
+/// `[DONE]` present but not terminated by a blank line, exactly as
+/// synthetic.new sends it (`...}}\n\ndata: [DONE]<EOF>`).
+fn sse_from_chunks_unterminated_done(chunks: Vec<Value>) -> String {
+    let mut sse = String::new();
+    for chunk in chunks {
+        sse.push_str("data: ");
+        sse.push_str(&chunk.to_string());
+        sse.push_str("\n\n");
+    }
+    sse.push_str("data: [DONE]");
+    sse
+}
+
 fn default_ok_sse() -> String {
     sse_from_chunks(vec![
         json!({"choices":[{"delta":{"role":"assistant","content":"OK"}}]}),
@@ -997,12 +1010,11 @@ async fn issue_26_non_glm_model_does_not_send_thinking() {
 
 #[tokio::test]
 async fn issue_31_stream_without_done_still_completes_when_content_received() {
-    // Some OpenAI-compatible providers (e.g. synthetic.new) close the SSE stream
-    // cleanly without ever sending a terminating `[DONE]` line. A turn that
-    // received content should still complete rather than be discarded.
+    // A provider that closes the SSE stream without a terminating `[DONE]`
+    // line, but did send `finish_reason`, has delivered a complete turn.
     let no_done_sse = sse_from_chunks_without_done(vec![
         json!({"choices":[{"delta":{"role":"assistant","content":"Hello"}}]}),
-        json!({"choices":[{"delta":{"content":" world"}}]}),
+        json!({"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}),
         json!({"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}),
     ]);
     let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![no_done_sse]).await;
@@ -1018,12 +1030,99 @@ async fn issue_31_stream_without_done_still_completes_when_content_received() {
         .iter()
         .find_map(|(event, data)| (event == "response.completed").then_some(data));
     let failed = events.iter().any(|(event, _)| event == "response.failed");
-    assert!(!failed, "stream should not fail when content was received");
+    assert!(!failed, "stream should not fail when the turn finished");
     let completed = completed.expect("response.completed");
     assert_eq!(
         completed["response"]["output"][0]["content"][0]["text"],
         "Hello world"
     );
+}
+
+#[tokio::test]
+async fn issue_31_unterminated_done_line_is_still_recognized() {
+    // synthetic.new ends the stream with `data: [DONE]` and no trailing
+    // newline. The SSE spec discards an unterminated final event at EOF, so
+    // without an explicit flush `[DONE]` is lost and every turn falls through
+    // to the `missing_done` quirk. Usage from the final chunk must survive too.
+    let sse = sse_from_chunks_unterminated_done(vec![
+        json!({"choices":[{"delta":{"role":"assistant","content":"OK"}}]}),
+        json!({"choices":[{"delta":{},"finish_reason":"stop"}],
+               "usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}),
+    ]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({"model": "mock-model", "input": "Say hi.", "tools": [], "stream": true}),
+    )
+    .await;
+
+    let completed = events
+        .iter()
+        .find_map(|(event, data)| (event == "response.completed").then_some(data))
+        .expect("response.completed");
+    assert_eq!(
+        completed["response"]["output"][0]["content"][0]["text"],
+        "OK"
+    );
+    assert_eq!(completed["response"]["usage"]["total_tokens"], 7);
+}
+
+#[tokio::test]
+async fn issue_31_truncated_stream_without_finish_reason_fails() {
+    // No `[DONE]` *and* no `finish_reason`: the connection died mid-generation.
+    // Completing here would persist a half-written turn into session history.
+    let truncated = sse_from_chunks_without_done(vec![
+        json!({"choices":[{"delta":{"role":"assistant","content":"Hel"}}]}),
+    ]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![truncated]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({"model": "mock-model", "input": "Say hi.", "tools": [], "stream": true}),
+    )
+    .await;
+
+    assert!(
+        events.iter().any(|(event, _)| event == "response.failed"),
+        "truncated turn must not be reported as completed"
+    );
+}
+
+#[tokio::test]
+async fn think_tags_leaked_into_content_are_routed_to_reasoning() {
+    // vLLM deployments without a `--reasoning-parser` emit chain of thought as
+    // `<think>` markup inside `content`. It must reach Codex as reasoning, not
+    // as assistant text — including when a tag straddles two chunks.
+    let sse = sse_from_chunks(vec![
+        json!({"choices":[{"delta":{"role":"assistant","content":"<thi"}}]}),
+        json!({"choices":[{"delta":{"content":"nk>musing</th"}}]}),
+        json!({"choices":[{"delta":{"content":"ink>\n\nHello!"},"finish_reason":"stop"}]}),
+    ]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({"model": "mock-model", "input": "Say hi.", "tools": [], "stream": true}),
+    )
+    .await;
+
+    let text: String = events
+        .iter()
+        .filter(|(event, _)| event == "response.output_text.delta")
+        .filter_map(|(_, data)| data["delta"].as_str())
+        .collect();
+    let reasoning: String = events
+        .iter()
+        .filter(|(event, _)| event == "response.reasoning_summary_text.delta")
+        .filter_map(|(_, data)| data["delta"].as_str())
+        .collect();
+
+    assert_eq!(text, "Hello!", "think markup must not reach visible text");
+    assert_eq!(reasoning, "musing");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- flush an unterminated final SSE event so data: [DONE] is recognized
- only apply missing_done recovery after an upstream finish_reason, preventing truncated turns from entering history
- route leaked explicit <think>...</think> markup to Responses reasoning in streaming and blocking paths
- persist the healed blocking assistant message rather than the raw tagged message

## Safety details

- ordinary text, including leading whitespace, remains byte-for-byte unchanged
- streaming repair recognizes balanced opening/closing tags, so classification is independent of SSE chunk boundaries
- close-only markup is handled only when the entire blocking message is available
- empty and unterminated think blocks cannot leak into visible output
- blocking Responses output includes a reasoning item and replayed history carries clean content plus reasoning_content

## Verification

- cargo test
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings