### PR TITLE
fix(translate): drop user/system messages that carry no content

### DIFF
--- a/src/translate.rs
+++ b/src/translate.rs
@@ -224,6 +224,8 @@ pub fn to_chat_request(
         }
     }
 
+    drop_contentless_messages(&mut messages);
+
     let mapped_model = map_model_name(&req.model);
     // GLM/Zhipu only emits reasoning_content when `thinking` is explicitly
     // enabled; its default auto-thinking is suppressed by heavy agent system
@@ -665,6 +667,71 @@ pub(crate) fn split_mcp_function_name(name: &str) -> (Option<String>, String) {
     )
 }
 
+/// True when a user/system message would reach the upstream carrying nothing.
+///
+/// `None`, `""`, whitespace, an empty parts array, or a parts array whose text
+/// parts are all blank and which has no image (or other non-text) part.
+fn is_contentless(msg: &ChatMessage) -> bool {
+    match &msg.content {
+        None => true,
+        Some(Value::String(s)) => s.trim().is_empty(),
+        Some(Value::Array(parts)) => parts.iter().all(|part| {
+            let kind = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            match kind {
+                "text" | "input_text" | "output_text" => part
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .map(|t| t.trim().is_empty())
+                    .unwrap_or(true),
+                // Images and unknown part types carry payload; keep them.
+                _ => false,
+            }
+        }),
+        Some(Value::Null) => true,
+        Some(_) => false,
+    }
+}
+
+/// Drop user/system messages that carry no content at all.
+///
+/// Several Chat Completions upstreams reject the WHOLE request when any
+/// message has empty content — Command Code answers
+/// `400 user message must have content, param=messages.N.content`. Because
+/// Codex replays its full thread history on every turn, one blank message
+/// persisted into that history bricks the thread permanently: every later
+/// turn 400s, the client retries and then closes the turn with no output and
+/// no error anyone can see (observed 2026-08-07, an image-only chat message
+/// that reached Codex as `{"type":"text","text":""}`).
+///
+/// Only user/system messages are eligible. An assistant message with empty
+/// content may still carry `tool_calls`, and a `tool` message is pinned to its
+/// call by `tool_call_id` — dropping either breaks the pairing the Chat
+/// Completions API requires. The last remaining message is never dropped
+/// either: an empty `messages` array is its own 400.
+fn drop_contentless_messages(messages: &mut Vec<ChatMessage>) {
+    let mut keep: Vec<bool> = Vec::with_capacity(messages.len());
+    let mut kept = 0usize;
+    for msg in messages.iter() {
+        let droppable = matches!(msg.role.as_str(), "user" | "system")
+            && msg.tool_calls.is_none()
+            && msg.tool_call_id.is_none()
+            && is_contentless(msg);
+        keep.push(!droppable);
+        if !droppable {
+            kept += 1;
+        }
+    }
+    if kept == 0 {
+        return;
+    }
+    let mut index = 0;
+    messages.retain(|_| {
+        let decision = keep[index];
+        index += 1;
+        decision
+    });
+}
+
 /// Translate a Responses-API `content` value to its Chat Completions equivalent.
 ///
 /// - Plain string → `Value::String`.
@@ -764,6 +831,92 @@ mod tests {
         assert_eq!(chat.messages.len(), 1);
         assert_eq!(chat.messages[0].role, "user");
         assert_eq!(chat.messages[0].text_content(), "hello");
+    }
+
+    #[test]
+    fn test_blank_user_message_in_history_is_dropped() {
+        // A single blank message persisted in a Codex thread bricked it:
+        // the upstream answered `400 user message must have content` for
+        // EVERY later turn, since Codex replays the whole history.
+        let sessions = SessionStore::new();
+        let req = base_req(ResponsesInput::Messages(vec![
+            json!({"type": "message", "role": "user", "content": "first"}),
+            json!({"type": "message", "role": "user", "content": [{"type": "input_text", "text": ""}]}),
+            json!({"type": "message", "role": "user", "content": "second"}),
+        ]));
+        let chat = to_chat_request(&req, vec![], &sessions);
+        let texts: Vec<&str> = chat.messages.iter().map(|m| m.text_content()).collect();
+        assert_eq!(texts, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn test_whitespace_only_user_message_is_dropped() {
+        let sessions = SessionStore::new();
+        let req = base_req(ResponsesInput::Messages(vec![
+            json!({"type": "message", "role": "user", "content": "   \n "}),
+            json!({"type": "message", "role": "user", "content": "real"}),
+        ]));
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert_eq!(chat.messages.len(), 1);
+        assert_eq!(chat.messages[0].text_content(), "real");
+    }
+
+    #[test]
+    fn test_image_only_message_is_kept() {
+        // No text, but there IS a payload — dropping it would lose the image.
+        let sessions = SessionStore::new();
+        let req = base_req(ResponsesInput::Messages(vec![json!({
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": ""},
+                {"type": "input_image", "image_url": "data:image/png;base64,AAA"}
+            ]
+        })]));
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert_eq!(chat.messages.len(), 1);
+        assert!(chat.messages[0].content.as_ref().unwrap().is_array());
+    }
+
+    #[test]
+    fn test_assistant_message_with_tool_calls_and_no_content_is_kept() {
+        // Empty content is legal — and required — for a tool-calling turn.
+        let mut messages = vec![
+            ChatMessage {
+                role: "assistant".into(),
+                content: None,
+                reasoning_content: None,
+                tool_calls: Some(vec![json!({"id": "c1"})]),
+                tool_call_id: None,
+                name: None,
+            },
+            ChatMessage {
+                role: "tool".into(),
+                content: Some(Value::String(String::new())),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: Some("c1".into()),
+                name: None,
+            },
+        ];
+        drop_contentless_messages(&mut messages);
+        assert_eq!(messages.len(), 2);
+    }
+
+    #[test]
+    fn test_never_empties_the_message_array() {
+        // An all-blank request must still be a well-formed one; let the
+        // upstream decide, rather than sending zero messages.
+        let mut messages = vec![ChatMessage {
+            role: "user".into(),
+            content: Some(Value::String(String::new())),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }];
+        drop_contentless_messages(&mut messages);
+        assert_eq!(messages.len(), 1);
     }
 
     #[test]

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -27,8 +27,17 @@ pub fn to_chat_request(
 ) -> ChatRequest {
     let mut messages = history;
 
+    // History can contain poison blank messages from an earlier turn. Remove
+    // them before deciding whether an existing system prompt suppresses the
+    // current request's instructions.
+    messages.retain(|msg| !is_droppable_contentless(msg));
+
     // Prefer `instructions` (Codex CLI) over `system` (other clients).
-    let system_text = req.instructions.as_ref().or(req.system.as_ref());
+    let system_text = req
+        .instructions
+        .as_ref()
+        .filter(|text| !text.trim().is_empty())
+        .or_else(|| req.system.as_ref().filter(|text| !text.trim().is_empty()));
     if let Some(system) = system_text {
         if messages.is_empty() || messages[0].role != "system" {
             messages.insert(
@@ -93,6 +102,16 @@ pub fn to_chat_request(
                 let item = &items[i];
                 let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
 
+                if is_contentless_response_message(item)
+                    && matches!(
+                        item.get("role").and_then(Value::as_str),
+                        Some("system" | "developer")
+                    )
+                {
+                    i += 1;
+                    continue;
+                }
+
                 if matches!(item_type, "function_call" | "custom_tool_call") {
                     // Skip function_call items whose call_id already exists in history.
                     // Duplicates occur when both previous_response_id and input replay
@@ -110,6 +129,10 @@ pub fn to_chat_request(
                     while i < items.len() {
                         let cur = &items[i];
                         let cur_type = cur.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                        if is_contentless_response_message(cur) {
+                            i += 1;
+                            continue;
+                        }
                         if !matches!(cur_type, "function_call" | "custom_tool_call") {
                             break;
                         }
@@ -672,9 +695,13 @@ pub(crate) fn split_mcp_function_name(name: &str) -> (Option<String>, String) {
 /// `None`, `""`, whitespace, an empty parts array, or a parts array whose text
 /// parts are all blank and which has no image (or other non-text) part.
 fn is_contentless(msg: &ChatMessage) -> bool {
-    match &msg.content {
+    is_content_value_contentless(msg.content.as_ref())
+}
+
+fn is_content_value_contentless(content: Option<&Value>) -> bool {
+    match content {
         None => true,
-        Some(Value::String(s)) => s.trim().is_empty(),
+        Some(Value::String(text)) => text.trim().is_empty(),
         Some(Value::Array(parts)) => parts.iter().all(|part| {
             let kind = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
             match kind {
@@ -690,6 +717,25 @@ fn is_contentless(msg: &ChatMessage) -> bool {
         Some(Value::Null) => true,
         Some(_) => false,
     }
+}
+
+fn is_droppable_contentless(msg: &ChatMessage) -> bool {
+    matches!(msg.role.as_str(), "user" | "system")
+        && msg.tool_calls.is_none()
+        && msg.tool_call_id.is_none()
+        && is_contentless(msg)
+}
+
+fn is_contentless_response_message(item: &Value) -> bool {
+    if !matches!(
+        item.get("type").and_then(Value::as_str),
+        Some("message" | "agent_message")
+    ) {
+        return false;
+    }
+    let role = item.get("role").and_then(Value::as_str).unwrap_or("user");
+    matches!(role, "user" | "system" | "developer")
+        && is_content_value_contentless(item.get("content"))
 }
 
 /// Drop user/system messages that carry no content at all.
@@ -709,27 +755,16 @@ fn is_contentless(msg: &ChatMessage) -> bool {
 /// Completions API requires. The last remaining message is never dropped
 /// either: an empty `messages` array is its own 400.
 fn drop_contentless_messages(messages: &mut Vec<ChatMessage>) {
-    let mut keep: Vec<bool> = Vec::with_capacity(messages.len());
-    let mut kept = 0usize;
-    for msg in messages.iter() {
-        let droppable = matches!(msg.role.as_str(), "user" | "system")
-            && msg.tool_calls.is_none()
-            && msg.tool_call_id.is_none()
-            && is_contentless(msg);
-        keep.push(!droppable);
-        if !droppable {
-            kept += 1;
-        }
-    }
-    if kept == 0 {
+    if messages.is_empty() {
         return;
     }
-    let mut index = 0;
-    messages.retain(|_| {
-        let decision = keep[index];
-        index += 1;
-        decision
-    });
+    if messages.iter().all(is_droppable_contentless) {
+        let newest = messages.pop().expect("messages is non-empty");
+        messages.clear();
+        messages.push(newest);
+    } else {
+        messages.retain(|msg| !is_droppable_contentless(msg));
+    }
 }
 
 /// Translate a Responses-API `content` value to its Chat Completions equivalent.
@@ -749,6 +784,7 @@ fn drop_contentless_messages(messages: &mut Vec<ChatMessage>) {
 fn value_to_chat_content(v: Option<&Value>) -> Option<Value> {
     match v {
         None => None,
+        Some(Value::Null) => None,
         Some(Value::String(s)) => Some(Value::String(s.clone())),
         Some(Value::Array(parts)) => {
             // `output_text` is what Codex replays for assistant history items;
@@ -862,6 +898,18 @@ mod tests {
     }
 
     #[test]
+    fn test_null_user_message_is_dropped() {
+        let sessions = SessionStore::new();
+        let req = base_req(ResponsesInput::Messages(vec![
+            json!({"type": "message", "role": "user", "content": null}),
+            json!({"type": "message", "role": "user", "content": "real"}),
+        ]));
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert_eq!(chat.messages.len(), 1);
+        assert_eq!(chat.messages[0].text_content(), "real");
+    }
+
+    #[test]
     fn test_image_only_message_is_kept() {
         // No text, but there IS a payload — dropping it would lose the image.
         let sessions = SessionStore::new();
@@ -920,6 +968,28 @@ mod tests {
     }
 
     #[test]
+    fn test_all_blank_messages_keep_only_the_newest() {
+        let mut messages = ["first", "second", "newest"]
+            .into_iter()
+            .map(|name| ChatMessage {
+                role: "user".into(),
+                content: Some(Value::String(if name == "newest" {
+                    "\n".into()
+                } else {
+                    String::new()
+                })),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: None,
+                name: Some(name.into()),
+            })
+            .collect();
+        drop_contentless_messages(&mut messages);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].name.as_deref(), Some("newest"));
+    }
+
+    #[test]
     fn test_system_prompt_from_instructions() {
         let sessions = SessionStore::new();
         let mut req = base_req(ResponsesInput::Text("hi".into()));
@@ -927,6 +997,46 @@ mod tests {
         let chat = to_chat_request(&req, vec![], &sessions);
         assert_eq!(chat.messages[0].role, "system");
         assert_eq!(chat.messages[0].text_content(), "be helpful");
+    }
+
+    #[test]
+    fn test_blank_developer_input_does_not_replace_instructions() {
+        let sessions = SessionStore::new();
+        let mut req = base_req(ResponsesInput::Messages(vec![
+            json!({"type": "message", "role": "developer", "content": "  "}),
+            json!({"type": "message", "role": "user", "content": "hi"}),
+        ]));
+        req.instructions = Some("be helpful".into());
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert_eq!(chat.messages[0].role, "system");
+        assert_eq!(chat.messages[0].text_content(), "be helpful");
+    }
+
+    #[test]
+    fn test_blank_history_system_does_not_suppress_instructions() {
+        let sessions = SessionStore::new();
+        let mut req = base_req(ResponsesInput::Text("hi".into()));
+        req.instructions = Some("current instructions".into());
+        let history = vec![ChatMessage {
+            role: "system".into(),
+            content: Some(String::new().into()),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        }];
+        let chat = to_chat_request(&req, history, &sessions);
+        assert_eq!(chat.messages[0].text_content(), "current instructions");
+    }
+
+    #[test]
+    fn test_blank_instructions_fall_back_to_system() {
+        let sessions = SessionStore::new();
+        let mut req = base_req(ResponsesInput::Text("hi".into()));
+        req.instructions = Some(" \n".into());
+        req.system = Some("system fallback".into());
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert_eq!(chat.messages[0].text_content(), "system fallback");
     }
 
     #[test]
@@ -954,6 +1064,27 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0]["id"], "c1");
         assert_eq!(calls[1]["id"], "c2");
+    }
+
+    #[test]
+    fn test_blank_messages_do_not_split_parallel_tool_calls() {
+        let sessions = SessionStore::new();
+        let req = base_req(ResponsesInput::Messages(vec![
+            json!({"type": "function_call", "call_id": "c1", "name": "fn_a", "arguments": "{}"}),
+            json!({"type": "message", "role": "user", "content": ""}),
+            json!({"type": "message", "role": "system", "content": []}),
+            json!({"type": "function_call", "call_id": "c2", "name": "fn_b", "arguments": "{}"}),
+            json!({"type": "function_call_output", "call_id": "c1", "output": "one"}),
+            json!({"type": "function_call_output", "call_id": "c2", "output": "two"}),
+        ]));
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert_eq!(chat.messages.len(), 3);
+        let calls = chat.messages[0].tool_calls.as_ref().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0]["id"], "c1");
+        assert_eq!(calls[1]["id"], "c2");
+        assert_eq!(chat.messages[1].tool_call_id.as_deref(), Some("c1"));
+        assert_eq!(chat.messages[2].tool_call_id.as_deref(), Some("c2"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Several Chat Completions upstreams reject requests containing empty user/system messages. Replayed history can therefore permanently poison a thread.

## Fix

Drop only provably contentless user/system messages while preserving assistant/tool protocol records and non-text payloads.

Additional safety handling:
- content: null is treated as empty rather than the literal string "null"
- blank history system messages cannot suppress current instructions
- blank developer/system input cannot replace a valid system prompt
- blank instructions fall back to a nonblank system field
- blank messages between parallel function calls are transparent, preserving one assistant tool_calls group and tool adjacency
- when every message is blank, retain only the newest fallback instead of retaining every poison message
- image and unknown non-text parts remain intact

The shared translation path covers streaming and blocking requests and stores the cleaned history.

## Verification

- cargo test
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings