### PR TITLE
feat(translate): forward reasoning.effort to upstream reasoning_effort

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -968,6 +968,7 @@ mod tests {
             max_output_tokens: None,
             system: None,
             instructions: None,
+            reasoning: None,
         };
         let history = vec![ChatMessage {
             role: "assistant".into(),
@@ -1000,6 +1001,7 @@ mod tests {
             max_output_tokens: None,
             system: None,
             instructions: None,
+            reasoning: None,
         };
         let history = vec![ChatMessage {
             role: "assistant".into(),
@@ -1032,6 +1034,7 @@ mod tests {
             max_output_tokens: None,
             system: None,
             instructions: None,
+            reasoning: None,
         };
         let history = vec![ChatMessage {
             role: "assistant".into(),
@@ -1078,6 +1081,7 @@ mod tests {
             max_output_tokens: None,
             system: None,
             instructions: None,
+            reasoning: None,
         };
         let history = vec![ChatMessage {
             role: "assistant".into(),
@@ -1110,6 +1114,7 @@ mod tests {
             max_output_tokens: None,
             system: None,
             instructions: None,
+            reasoning: None,
         };
         let history = vec![
             ChatMessage {

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -246,6 +246,14 @@ pub fn to_chat_request(
         thinking: enable_glm_thinking.then(|| ChatThinking {
             kind: "enabled".into(),
         }),
+        // Forwarded verbatim; see ChatRequest::reasoning_effort for why the
+        // relay does not validate or remap the value. Absent when Codex sends
+        // `"reasoning": null`, which it does for any model missing from its
+        // model catalog — in that case nothing is added to the upstream body.
+        reasoning_effort: req
+            .reasoning
+            .as_ref()
+            .and_then(|reasoning| reasoning.effort.clone()),
         stream: req.stream,
     }
 }
@@ -753,7 +761,56 @@ mod tests {
             max_output_tokens: None,
             system: None,
             instructions: None,
+            reasoning: None,
         }
+    }
+
+    #[test]
+    fn test_reasoning_effort_is_forwarded_verbatim() {
+        let sessions = SessionStore::new();
+        let mut req = base_req(ResponsesInput::Text("hello".into()));
+        req.reasoning = Some(ResponsesReasoning {
+            effort: Some("xhigh".into()),
+        });
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert_eq!(chat.reasoning_effort.as_deref(), Some("xhigh"));
+        // Serialized shape matters: upstreams read a top-level string field.
+        let body = serde_json::to_value(&chat).unwrap();
+        assert_eq!(body["reasoning_effort"], json!("xhigh"));
+    }
+
+    #[test]
+    fn test_absent_reasoning_omits_the_field() {
+        // Codex sends `"reasoning": null` for any model missing from its model
+        // catalog. Nothing must be added to the upstream body in that case, or
+        // providers that reject unknown fields would start failing.
+        let sessions = SessionStore::new();
+        let req = base_req(ResponsesInput::Text("hello".into()));
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert!(chat.reasoning_effort.is_none());
+        let body = serde_json::to_value(&chat).unwrap();
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_explicit_null_reasoning_deserializes_to_none() {
+        let req: ResponsesRequest = serde_json::from_value(json!({
+            "model": "deepseek/deepseek-v4-flash",
+            "input": "hi",
+            "reasoning": null,
+        }))
+        .unwrap();
+        assert!(req.reasoning.is_none());
+    }
+
+    #[test]
+    fn test_reasoning_without_effort_forwards_nothing() {
+        // `{"reasoning": {"summary": "auto"}}` carries no budget to forward.
+        let sessions = SessionStore::new();
+        let mut req = base_req(ResponsesInput::Text("hello".into()));
+        req.reasoning = Some(ResponsesReasoning { effort: None });
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert!(chat.reasoning_effort.is_none());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,6 +22,20 @@ pub struct ResponsesRequest {
     pub system: Option<String>,
     #[serde(default)]
     pub instructions: Option<String>,
+    /// Responses-API reasoning controls. Codex sends `"reasoning": null` for
+    /// models it believes have no reasoning support, so this must tolerate an
+    /// explicit null as well as a missing key.
+    #[serde(default)]
+    pub reasoning: Option<ResponsesReasoning>,
+}
+
+/// Reasoning block of a Responses request. Only `effort` maps onto Chat
+/// Completions; `summary` has no counterpart there and is intentionally
+/// dropped (reasoning text comes back via `reasoning_content` instead).
+#[derive(Debug, Deserialize, Default)]
+pub struct ResponsesReasoning {
+    #[serde(default)]
+    pub effort: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -84,6 +98,17 @@ pub struct ChatRequest {
     /// be sent explicitly for reasoning to be emitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thinking: Option<ChatThinking>,
+    /// Reasoning budget, forwarded verbatim from the Responses request's
+    /// `reasoning.effort`. Deliberately a free-form String rather than an enum:
+    /// the accepted set is the upstream's business, not the relay's, and it
+    /// differs per provider (Command Code takes low|medium|high|xhigh|max and
+    /// rejects none/minimal; OpenRouter and OpenAI take other sets). Passing it
+    /// through unchanged means an unsupported value surfaces as the upstream's
+    /// own error instead of being silently rewritten here. Use
+    /// `--drop-upstream-params '["reasoning_effort"]'` to strip it for an
+    /// upstream that chokes on the field entirely.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
     pub stream: bool,
 }
 

--- a/src/upstream_request.rs
+++ b/src/upstream_request.rs
@@ -95,6 +95,7 @@ mod tests {
             max_tokens: Some(100),
             stream_options: None,
             thinking: None,
+            reasoning_effort: None,
             stream: false,
         }
     }

--- a/tests/compat_deepseek_v4_pro.rs
+++ b/tests/compat_deepseek_v4_pro.rs
@@ -22,6 +22,7 @@ fn base_req(input: ResponsesInput) -> ResponsesRequest {
         max_output_tokens: None,
         system: None,
         instructions: None,
+        reasoning: None,
     }
 }
 


### PR DESCRIPTION
## Problem

Codex sends the reasoning budget as `reasoning.effort` on the Responses request. `ResponsesRequest` had no such field, so serde dropped it and `ChatRequest` had nothing to send.

Net effect: `model_reasoning_effort` in `config.toml` and the TUI's `/model` effort picker **silently did nothing** for every Chat Completions upstream. The status line reports the configured level, the upstream never hears about it.

## Fix

Add `ResponsesRequest.reasoning` and `ChatRequest.reasoning_effort`, and map effort across in `to_chat_request`.

The inbound field must tolerate an explicit `"reasoning": null` — that is what Codex sends for any model missing from its model catalog, which is the common case for a relayed provider.

**The value is forwarded verbatim, not validated or remapped.** The accepted set belongs to the upstream and differs per provider:

| upstream | accepted |
|---|---|
| Command Code | `low` `medium` `high` `xhigh` `max` (rejects `none`/`minimal`) |
| OpenAI / OpenRouter | their own sets |

An unsupported value should surface as the upstream's own error rather than be silently rewritten in the relay. An upstream that rejects the field outright can strip it with the existing `--drop-upstream-params '["reasoning_effort"]'`.

## Verification

End to end against Codex 0.144.5 → relay → Command Code → `deepseek/deepseek-v4-flash`, capturing the upstream body with a stub server:

```
codex -c model_reasoning_effort=low    → "reasoning_effort": "low"
codex -c model_reasoning_effort=xhigh  → "reasoning_effort": "xhigh"
codex -c model_reasoning_effort=max    → "reasoning_effort": "max"
```

Note for anyone testing this: do **not** try to verify by comparing reasoning token counts. The variance swamps the signal — on one fixed prompt I measured low 642 / medium 548 / high 1380 / xhigh 1950 / max 1233 on single samples. Capture the request body instead.

Caveat worth knowing: Codex only emits the `reasoning` field at all for models present in its own model catalog. For a relayed model you also need a `model_catalog_json` entry on the Codex side, or the request carries `"reasoning": null` and there is nothing for the relay to forward.

## Tests

4 new unit tests: verbatim forwarding, absent reasoning omitting the field entirely, explicit `null` deserializing to `None`, and `reasoning` present without `effort`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)