### PR TITLE
fix(dsml): heal the doubled-delimiter DSML dialect leaked by V4 Flash

### DIFF
--- a/src/dsml.rs
+++ b/src/dsml.rs
@@ -41,6 +41,7 @@
 //! tag has no body, so its value can only live in an attribute.
 
 use serde_json::{json, Value};
+use std::collections::BTreeMap;
 
 use crate::types::ChatMessage;
 
@@ -103,132 +104,325 @@ pub struct DsmlToolCall {
 /// complete `<｜DSML｜invoke>` block could be parsed (the text is then left
 /// untouched so nothing is lost).
 pub fn parse_leaked_tool_calls(text: &str) -> Option<(String, Vec<DsmlToolCall>)> {
-    let (dialect, _) = detect_dialect(text)?;
     let mut calls = Vec::new();
     let mut cleaned = String::new();
-    let mut rest = text;
+    let mut copied_through = 0;
+    let mut search_from = 0;
 
-    while let Some(start) = rest.find(dialect.invoke_open) {
-        let header_start = start + dialect.invoke_open.len();
-        let Some(header_len) = unquoted_char(&rest[header_start..], '>') else {
-            break;
-        };
-        let header = &rest[header_start..header_start + header_len];
-        let body_start = header_start + header_len + 1;
-        let Some(body_len) = rest[body_start..].find(dialect.invoke_close) else {
-            break;
-        };
-        let Some(name) = attribute(header, "name") else {
-            break;
-        };
-        let arguments = parse_parameters(&rest[body_start..body_start + body_len], dialect);
-        calls.push(DsmlToolCall {
-            name: name.to_string(),
-            arguments: Value::Object(arguments).to_string(),
-        });
-        cleaned.push_str(&rest[..start]);
-        rest = &rest[body_start + body_len + dialect.invoke_close.len()..];
+    while let Some((dialect, start)) = find_next_invoke(text, search_from) {
+        match parse_invoke(text, start, dialect) {
+            Ok((end, call)) => {
+                let removal_start = envelope_start(text, copied_through, start, dialect);
+                let removal_end = envelope_end(text, end, dialect);
+                cleaned.push_str(&text[copied_through..removal_start]);
+                calls.push(call);
+                copied_through = removal_end;
+                search_from = removal_end;
+            }
+            Err(()) => {
+                // Preserve malformed candidates byte-for-byte, but continue so
+                // an unrelated valid call later in the message can still heal.
+                let Some(end) = malformed_invoke_end(text, start, dialect) else {
+                    break;
+                };
+                search_from = end;
+            }
+        }
     }
 
     if calls.is_empty() {
         return None;
     }
-    cleaned.push_str(rest);
-    let cleaned = cleaned
-        .replace(dialect.calls_open, "")
-        .replace(dialect.calls_close, "");
+    cleaned.push_str(&text[copied_through..]);
     Some((cleaned.trim().to_string(), calls))
 }
 
-/// Parse the parameter tags inside one `invoke` body.
-///
-/// Tags are matched on the dialect marker rather than on a fixed tag name:
-/// single-bar leaks name them `parameter`, double-bar leaks reuse `invoke`.
-/// What actually distinguishes a value's location is the tag's *shape*:
-///
-/// - self-closing (`… />`) — no body exists, so the value is the `string`
-///   attribute (double-bar form).
-/// - with a body — the value is the body text, and `string="false"` marks it
-///   as a non-string JSON literal (single-bar form).
-fn parse_parameters(body: &str, dialect: DsmlDialect) -> serde_json::Map<String, Value> {
-    let mut arguments = serde_json::Map::new();
-    let mut rest = body;
-    while let Some(start) = rest.find(dialect.marker) {
-        let header_start = start + dialect.marker.len();
-        let Some(header_len) = unquoted_char(&rest[header_start..], '>') else {
-            break;
-        };
-        let header = &rest[header_start..header_start + header_len];
-        let after_tag = header_start + header_len + 1;
-
-        let Some(tag) = header.split_whitespace().next() else {
-            break;
-        };
-        // A closing tag (`</…invoke>`) means the enclosing element ended; the
-        // marker search cannot see `</` because the marker starts with `<`, so
-        // this only guards against a malformed header.
-        if tag.starts_with('/') {
-            rest = &rest[after_tag..];
-            continue;
-        }
-
-        if header.trim_end().ends_with('/') {
-            if let Some(name) = attribute(header, "name") {
-                let value = attribute(header, "string").unwrap_or_default();
-                arguments.insert(name.to_string(), Value::String(value.to_string()));
-            }
-            rest = &rest[after_tag..];
-            continue;
-        }
-
-        let close = format!("</{}{}>", dialect.marker.trim_start_matches('<'), tag);
-        let Some(value_len) = rest[after_tag..].find(&close) else {
-            break;
-        };
-        let raw = &rest[after_tag..after_tag + value_len];
-        if let Some(name) = attribute(header, "name") {
-            // string="false" marks a non-string JSON value (number, bool, ...).
-            let value = if attribute(header, "string") == Some("false") {
-                serde_json::from_str::<Value>(raw.trim())
-                    .unwrap_or_else(|_| Value::String(raw.to_string()))
-            } else {
-                Value::String(raw.to_string())
-            };
-            arguments.insert(name.to_string(), value);
-        }
-        rest = &rest[after_tag + value_len + close.len()..];
-    }
-    arguments
+#[derive(Debug)]
+struct ParsedTag {
+    name: String,
+    attrs: BTreeMap<String, String>,
+    self_closing: bool,
+    end: usize,
 }
 
-/// Byte offset of the first `needle` in `text` that is outside double quotes.
-fn unquoted_char(text: &str, needle: char) -> Option<usize> {
-    let mut in_quotes = false;
-    for (i, c) in text.char_indices() {
-        match c {
-            '"' => in_quotes = !in_quotes,
-            c if c == needle && !in_quotes => return Some(i),
-            _ => {}
+fn find_next_invoke(text: &str, from: usize) -> Option<(DsmlDialect, usize)> {
+    DIALECTS
+        .iter()
+        .filter_map(|dialect| {
+            let mut offset = from;
+            while let Some(found) = text[offset..].find(dialect.invoke_open) {
+                let start = offset + found;
+                let after = start + dialect.invoke_open.len();
+                if text[after..]
+                    .chars()
+                    .next()
+                    .is_some_and(|ch| ch.is_whitespace() || ch == '>')
+                {
+                    return Some((*dialect, start));
+                }
+                offset = after;
+            }
+            None
+        })
+        .min_by_key(|(_, start)| *start)
+}
+
+fn parse_invoke(
+    text: &str,
+    start: usize,
+    dialect: DsmlDialect,
+) -> Result<(usize, DsmlToolCall), ()> {
+    let invoke = parse_open_tag(text, start, dialect)?;
+    if invoke.name != "invoke" || invoke.self_closing {
+        return Err(());
+    }
+    let name = invoke
+        .attrs
+        .get("name")
+        .filter(|name| !name.is_empty())
+        .ok_or(())?;
+    let mut arguments = serde_json::Map::new();
+    let mut cursor = invoke.end;
+
+    loop {
+        cursor = skip_whitespace(text, cursor);
+        if text[cursor..].starts_with(dialect.invoke_close) {
+            let end = cursor + dialect.invoke_close.len();
+            return Ok((
+                end,
+                DsmlToolCall {
+                    name: name.clone(),
+                    arguments: Value::Object(arguments).to_string(),
+                },
+            ));
+        }
+        if !text[cursor..].starts_with(dialect.marker) {
+            return Err(());
+        }
+
+        let parameter = parse_open_tag(text, cursor, dialect)?;
+        let parameter_name = parameter
+            .attrs
+            .get("name")
+            .filter(|name| !name.is_empty())
+            .ok_or(())?
+            .clone();
+        if arguments.contains_key(&parameter_name) {
+            return Err(());
+        }
+
+        let value = if dialect == DOUBLE_BAR && parameter.name == "invoke" && parameter.self_closing
+        {
+            Value::String(parameter.attrs.get("string").ok_or(())?.clone())
+        } else if parameter.name == "parameter" && !parameter.self_closing {
+            let string_kind = parameter
+                .attrs
+                .get("string")
+                .map(String::as_str)
+                .ok_or(())?;
+            if !matches!(string_kind, "true" | "false") {
+                return Err(());
+            }
+            let close = format!("</{}parameter>", dialect.marker.trim_start_matches('<'));
+            let tail = &text[parameter.end..];
+            let close_offset = tail.find(&close).ok_or(())?;
+            if tail
+                .find(dialect.marker)
+                .into_iter()
+                .chain(tail.find(dialect.invoke_close))
+                .any(|offset| offset < close_offset)
+            {
+                return Err(());
+            }
+            let close_at = parameter.end + close_offset;
+            let raw = &text[parameter.end..close_at];
+            cursor = close_at + close.len();
+            if string_kind == "false" {
+                serde_json::from_str(raw.trim()).map_err(|_| ())?
+            } else {
+                Value::String(raw.to_string())
+            }
+        } else {
+            return Err(());
+        };
+        if parameter.self_closing {
+            cursor = parameter.end;
+        }
+        arguments.insert(parameter_name, value);
+    }
+}
+
+/// Find the balanced end of a malformed invoke so recovery never descends
+/// into a nested, valid-looking call and executes it out of context.
+fn malformed_invoke_end(text: &str, start: usize, dialect: DsmlDialect) -> Option<usize> {
+    let outer = parse_open_tag(text, start, dialect).ok()?;
+    if outer.name != "invoke" || outer.self_closing {
+        return Some(outer.end);
+    }
+    let mut depth = 1usize;
+    let mut cursor = outer.end;
+    while cursor < text.len() {
+        let next_open = text[cursor..]
+            .find(dialect.marker)
+            .map(|offset| cursor + offset);
+        let next_close = text[cursor..]
+            .find(dialect.invoke_close)
+            .map(|offset| cursor + offset);
+        match (next_open, next_close) {
+            (None, Some(close)) => {
+                depth -= 1;
+                cursor = close + dialect.invoke_close.len();
+                if depth == 0 {
+                    return Some(cursor);
+                }
+            }
+            (Some(open), Some(close)) if close < open => {
+                depth -= 1;
+                cursor = close + dialect.invoke_close.len();
+                if depth == 0 {
+                    return Some(cursor);
+                }
+            }
+            (Some(open), _) => {
+                let tag = parse_open_tag(text, open, dialect).ok()?;
+                if tag.name == "invoke" && !tag.self_closing {
+                    depth += 1;
+                }
+                cursor = tag.end;
+            }
+            (None, None) => return None,
         }
     }
     None
 }
 
-/// Extract a `key="value"` attribute from a DSML tag header.
-fn attribute<'a>(header: &'a str, key: &str) -> Option<&'a str> {
-    let mut rest = header;
-    loop {
-        let start = rest.find(key)?;
-        let after = &rest[start + key.len()..];
-        // Guard against matching `name` inside another attribute's key.
-        let preceded_ok = rest[..start].ends_with(char::is_whitespace) || start == 0;
-        if preceded_ok {
-            if let Some(after_eq) = after.strip_prefix("=\"") {
-                let end = after_eq.find('"')?;
-                return Some(&after_eq[..end]);
-            }
+fn parse_open_tag(text: &str, start: usize, dialect: DsmlDialect) -> Result<ParsedTag, ()> {
+    if !text[start..].starts_with(dialect.marker) {
+        return Err(());
+    }
+    let mut cursor = start + dialect.marker.len();
+    let name_start = cursor;
+    while let Some(ch) = text[cursor..].chars().next() {
+        if ch.is_whitespace() || matches!(ch, '/' | '>') {
+            break;
         }
-        rest = after;
+        cursor += ch.len_utf8();
+    }
+    if cursor == name_start {
+        return Err(());
+    }
+    let name = text[name_start..cursor].to_string();
+    let mut attrs = BTreeMap::new();
+
+    loop {
+        cursor = skip_whitespace(text, cursor);
+        match text[cursor..].chars().next().ok_or(())? {
+            '>' => {
+                return Ok(ParsedTag {
+                    name,
+                    attrs,
+                    self_closing: false,
+                    end: cursor + 1,
+                });
+            }
+            '/' => {
+                cursor += 1;
+                cursor = skip_whitespace(text, cursor);
+                if !text[cursor..].starts_with('>') {
+                    return Err(());
+                }
+                return Ok(ParsedTag {
+                    name,
+                    attrs,
+                    self_closing: true,
+                    end: cursor + 1,
+                });
+            }
+            _ => {}
+        }
+
+        let key_start = cursor;
+        while let Some(ch) = text[cursor..].chars().next() {
+            if ch.is_whitespace() || ch == '=' {
+                break;
+            }
+            if matches!(ch, '/' | '>') {
+                return Err(());
+            }
+            cursor += ch.len_utf8();
+        }
+        if cursor == key_start {
+            return Err(());
+        }
+        let key = text[key_start..cursor].to_string();
+        cursor = skip_whitespace(text, cursor);
+        if !text[cursor..].starts_with('=') {
+            return Err(());
+        }
+        cursor += 1;
+        cursor = skip_whitespace(text, cursor);
+        if !text[cursor..].starts_with('"') {
+            return Err(());
+        }
+        cursor += 1;
+        let (value, end) = parse_quoted_value(text, cursor)?;
+        cursor = end;
+        if attrs.insert(key, value).is_some() {
+            return Err(());
+        }
+    }
+}
+
+fn parse_quoted_value(text: &str, mut cursor: usize) -> Result<(String, usize), ()> {
+    let mut value = String::new();
+    loop {
+        let ch = text[cursor..].chars().next().ok_or(())?;
+        cursor += ch.len_utf8();
+        match ch {
+            '"' => return Ok((value, cursor)),
+            '\\' => {
+                let escaped = text[cursor..].chars().next().ok_or(())?;
+                if matches!(escaped, '"' | '\\') {
+                    value.push(escaped);
+                    cursor += escaped.len_utf8();
+                } else {
+                    value.push('\\');
+                }
+            }
+            other => value.push(other),
+        }
+    }
+}
+
+fn skip_whitespace(text: &str, mut cursor: usize) -> usize {
+    while let Some(ch) = text[cursor..].chars().next() {
+        if !ch.is_whitespace() {
+            break;
+        }
+        cursor += ch.len_utf8();
+    }
+    cursor
+}
+
+fn envelope_start(
+    text: &str,
+    copied_through: usize,
+    invoke_start: usize,
+    dialect: DsmlDialect,
+) -> usize {
+    let prefix = &text[copied_through..invoke_start];
+    prefix
+        .rfind(dialect.calls_open)
+        .filter(|at| prefix[at + dialect.calls_open.len()..].trim().is_empty())
+        .map_or(invoke_start, |at| copied_through + at)
+}
+
+fn envelope_end(text: &str, invoke_end: usize, dialect: DsmlDialect) -> usize {
+    let after_whitespace = skip_whitespace(text, invoke_end);
+    if text[after_whitespace..].starts_with(dialect.calls_close) {
+        after_whitespace + dialect.calls_close.len()
+    } else {
+        invoke_end
     }
 }
 
@@ -427,6 +621,17 @@ mod tests {
     }
 
     #[test]
+    fn double_bar_attribute_parser_handles_escapes_and_tag_text() {
+        let text = "<｜｜DSML｜｜invoke name=\"exec_command\">\n<｜｜DSML｜｜invoke name=\"cmd\" string=\"printf \\\"a>b\\\" C:\\temp\\file </｜｜DSML｜｜invoke>\" />\n</｜｜DSML｜｜invoke>";
+        let (_, calls) = parse_leaked_tool_calls(text).expect("healed");
+        let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert_eq!(
+            args["cmd"],
+            "printf \"a>b\" C:\\temp\\file </｜｜DSML｜｜invoke>"
+        );
+    }
+
+    #[test]
     fn double_bar_supports_bodied_parameters_too() {
         // Not observed in the wild, but the dialect differs only in the
         // delimiter; a bodied parameter must not silently drop its value.
@@ -435,6 +640,80 @@ mod tests {
         let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
         assert_eq!(args["command"], "ls -la");
         assert_eq!(args["timeout"], 15);
+    }
+
+    #[test]
+    fn parses_mixed_dialects_in_source_order() {
+        for text in [
+            format!("{ENVELOPE}\n{DOUBLE_BAR_ENVELOPE}"),
+            format!("{DOUBLE_BAR_ENVELOPE}\n{ENVELOPE}"),
+        ] {
+            let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("healed");
+            assert_eq!(cleaned, "");
+            assert_eq!(calls.len(), 2);
+            if text.starts_with("<｜DSML｜") {
+                assert_eq!(calls[0].name, "shell");
+                assert_eq!(calls[1].name, "exec_command");
+            } else {
+                assert_eq!(calls[0].name, "exec_command");
+                assert_eq!(calls[1].name, "shell");
+            }
+        }
+    }
+
+    #[test]
+    fn malformed_marker_does_not_block_later_valid_dialect() {
+        let malformed = "<｜DSML｜invoke_extra name=\"not_a_call\">raw</｜DSML｜invoke_extra>";
+        let text = format!("{malformed}\n{DOUBLE_BAR_ENVELOPE}");
+        let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("later call healed");
+        assert_eq!(cleaned, malformed);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "exec_command");
+    }
+
+    #[test]
+    fn malformed_calls_fail_closed() {
+        let cases = [
+            "<｜｜DSML｜｜invoke_extra name=\"exec_command\"></｜｜DSML｜｜invoke>",
+            "<｜｜DSML｜｜invoke name=\"exec_command\"><｜｜DSML｜｜metadata name=\"cmd\" string=\"echo bad\" /></｜｜DSML｜｜invoke>",
+            "<｜｜DSML｜｜invoke name=\"exec_command\"><｜｜DSML｜｜invoke name=\"cmd\" /></｜｜DSML｜｜invoke>",
+            "<｜｜DSML｜｜invoke name=\"exec_command\" name=\"other\"></｜｜DSML｜｜invoke>",
+            "<｜｜DSML｜｜invoke name=\"exec_command\"><｜｜DSML｜｜invoke name=\"cmd\" string=\"one\" /><｜｜DSML｜｜invoke name=\"cmd\" string=\"two\" /></｜｜DSML｜｜invoke>",
+            "<｜｜DSML｜｜invoke name=\"exec_command\"><｜｜DSML｜｜invoke name=\"cmd\" string=\"unterminated /></｜｜DSML｜｜invoke>",
+        ];
+        for text in cases {
+            assert!(
+                parse_leaked_tool_calls(text).is_none(),
+                "malformed DSML must not execute: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_call_is_preserved_when_later_call_heals() {
+        let malformed =
+            "<｜｜DSML｜｜invoke name=\"bad\"><｜｜DSML｜｜invoke name=\"cmd\" /></｜｜DSML｜｜invoke>";
+        let text = format!("{malformed}\n{ENVELOPE}");
+        let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("later call healed");
+        assert_eq!(cleaned, malformed);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "shell");
+    }
+
+    #[test]
+    fn nested_call_inside_malformed_invoke_never_executes() {
+        let malformed = "<｜｜DSML｜｜invoke name=\"bad\">\n<｜｜DSML｜｜invoke name=\"exec_command\">\n<｜｜DSML｜｜invoke name=\"cmd\" string=\"echo bad\" />\n</｜｜DSML｜｜invoke>\n</｜｜DSML｜｜invoke>";
+        let text = format!("{malformed}\n{ENVELOPE}");
+        let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("later sibling healed");
+        assert_eq!(cleaned, malformed);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "shell");
+    }
+
+    #[test]
+    fn unclosed_parameter_cannot_borrow_close_from_nested_call() {
+        let text = "<｜DSML｜invoke name=\"shell\">\n<｜DSML｜parameter name=\"command\" string=\"true\">echo bad\n<｜DSML｜invoke name=\"shell\">\n<｜DSML｜parameter name=\"command\" string=\"true\">echo good</｜DSML｜parameter>\n</｜DSML｜invoke>";
+        assert!(parse_leaked_tool_calls(text).is_none());
     }
 
     #[test]
@@ -470,6 +749,21 @@ mod tests {
         assert_eq!(calls[0].name, "exec_command");
         let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
         assert_eq!(args["cmd"], "echo alpha");
+    }
+
+    #[test]
+    fn stream_filter_handles_mixed_dialects_one_character_at_a_time() {
+        let text = format!("prefix\n{ENVELOPE}\n{DOUBLE_BAR_ENVELOPE}");
+        let mut filter = DsmlStreamFilter::default();
+        let mut emitted = String::new();
+        for ch in text.chars() {
+            emitted.push_str(&filter.push(&ch.to_string()));
+        }
+        let (leftover, calls) = filter.finish();
+        assert_eq!(format!("{emitted}{leftover}"), "prefix\n");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].name, "shell");
+        assert_eq!(calls[1].name, "exec_command");
     }
 
     #[test]

--- a/src/dsml.rs
+++ b/src/dsml.rs
@@ -19,20 +19,76 @@
 //! the markup from the visible text. The `｜` (U+FF5C) delimiters are
 //! DeepSeek-internal tokens that never appear in legitimate output, so
 //! healing is always on.
+//!
+//! # Dialects
+//!
+//! V4 Flash leaks a *doubled* delimiter and expresses parameters as
+//! self-closing `invoke` tags whose value sits in the `string` attribute
+//! (observed 2026-08-07 via Command Code):
+//!
+//! ```text
+//! <｜｜DSML｜｜tool_calls>
+//! <｜｜DSML｜｜invoke name="exec_command">
+//! <｜｜DSML｜｜invoke name="cmd" string="echo alpha" />
+//! </｜｜DSML｜｜invoke>
+//! </｜｜DSML｜｜tool_calls>
+//! ```
+//!
+//! Matching only the single-bar form made healing a no-op for that model: the
+//! marker search missed, `parse_leaked_tool_calls` returned `None`, and the
+//! raw markup reached Codex as plain text. Both delimiters are handled now,
+//! and parameters are read by *shape* rather than by tag name — a self-closing
+//! tag has no body, so its value can only live in an attribute.
 
 use serde_json::{json, Value};
 
 use crate::types::ChatMessage;
 
-/// Prefix common to every DSML tag.
-pub const DSML_MARKER: &str = "<｜DSML｜";
+/// One delimiter flavour of the DSML markup.
+///
+/// Everything is spelled out per dialect rather than concatenated from a
+/// prefix, so a mistyped delimiter fails to compile instead of silently
+/// producing a marker that never matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DsmlDialect {
+    /// Prefix common to every opening tag of this dialect.
+    marker: &'static str,
+    invoke_open: &'static str,
+    invoke_close: &'static str,
+    calls_open: &'static str,
+    calls_close: &'static str,
+}
 
-const INVOKE_OPEN: &str = "<｜DSML｜invoke";
-const INVOKE_CLOSE: &str = "</｜DSML｜invoke>";
-const PARAM_OPEN: &str = "<｜DSML｜parameter";
-const PARAM_CLOSE: &str = "</｜DSML｜parameter>";
-const CALLS_OPEN: &str = "<｜DSML｜tool_calls>";
-const CALLS_CLOSE: &str = "</｜DSML｜tool_calls>";
+/// `<｜DSML｜…>` — V3.2 / V4 Pro.
+const SINGLE_BAR: DsmlDialect = DsmlDialect {
+    marker: "<｜DSML｜",
+    invoke_open: "<｜DSML｜invoke",
+    invoke_close: "</｜DSML｜invoke>",
+    calls_open: "<｜DSML｜tool_calls>",
+    calls_close: "</｜DSML｜tool_calls>",
+};
+
+/// `<｜｜DSML｜｜…>` — V4 Flash.
+const DOUBLE_BAR: DsmlDialect = DsmlDialect {
+    marker: "<｜｜DSML｜｜",
+    invoke_open: "<｜｜DSML｜｜invoke",
+    invoke_close: "</｜｜DSML｜｜invoke>",
+    calls_open: "<｜｜DSML｜｜tool_calls>",
+    calls_close: "</｜｜DSML｜｜tool_calls>",
+};
+
+/// Double-bar first: `<｜DSML｜` is not a substring of `<｜｜DSML｜｜` (the `<`
+/// is followed by two bars there), but probing the more specific form first
+/// keeps that independent of the delimiters ever changing.
+const DIALECTS: [DsmlDialect; 2] = [DOUBLE_BAR, SINGLE_BAR];
+
+/// The dialect whose marker appears earliest in `text`, if any.
+fn detect_dialect(text: &str) -> Option<(DsmlDialect, usize)> {
+    DIALECTS
+        .iter()
+        .filter_map(|dialect| text.find(dialect.marker).map(|at| (*dialect, at)))
+        .min_by_key(|(_, at)| *at)
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DsmlToolCall {
@@ -47,54 +103,89 @@ pub struct DsmlToolCall {
 /// complete `<｜DSML｜invoke>` block could be parsed (the text is then left
 /// untouched so nothing is lost).
 pub fn parse_leaked_tool_calls(text: &str) -> Option<(String, Vec<DsmlToolCall>)> {
+    let (dialect, _) = detect_dialect(text)?;
     let mut calls = Vec::new();
     let mut cleaned = String::new();
     let mut rest = text;
 
-    while let Some(start) = rest.find(INVOKE_OPEN) {
-        let header_start = start + INVOKE_OPEN.len();
+    while let Some(start) = rest.find(dialect.invoke_open) {
+        let header_start = start + dialect.invoke_open.len();
         let Some(header_len) = unquoted_char(&rest[header_start..], '>') else {
             break;
         };
         let header = &rest[header_start..header_start + header_len];
         let body_start = header_start + header_len + 1;
-        let Some(body_len) = rest[body_start..].find(INVOKE_CLOSE) else {
+        let Some(body_len) = rest[body_start..].find(dialect.invoke_close) else {
             break;
         };
         let Some(name) = attribute(header, "name") else {
             break;
         };
-        let arguments = parse_parameters(&rest[body_start..body_start + body_len]);
+        let arguments = parse_parameters(&rest[body_start..body_start + body_len], dialect);
         calls.push(DsmlToolCall {
             name: name.to_string(),
             arguments: Value::Object(arguments).to_string(),
         });
         cleaned.push_str(&rest[..start]);
-        rest = &rest[body_start + body_len + INVOKE_CLOSE.len()..];
+        rest = &rest[body_start + body_len + dialect.invoke_close.len()..];
     }
 
     if calls.is_empty() {
         return None;
     }
     cleaned.push_str(rest);
-    let cleaned = cleaned.replace(CALLS_OPEN, "").replace(CALLS_CLOSE, "");
+    let cleaned = cleaned
+        .replace(dialect.calls_open, "")
+        .replace(dialect.calls_close, "");
     Some((cleaned.trim().to_string(), calls))
 }
 
-fn parse_parameters(body: &str) -> serde_json::Map<String, Value> {
+/// Parse the parameter tags inside one `invoke` body.
+///
+/// Tags are matched on the dialect marker rather than on a fixed tag name:
+/// single-bar leaks name them `parameter`, double-bar leaks reuse `invoke`.
+/// What actually distinguishes a value's location is the tag's *shape*:
+///
+/// - self-closing (`… />`) — no body exists, so the value is the `string`
+///   attribute (double-bar form).
+/// - with a body — the value is the body text, and `string="false"` marks it
+///   as a non-string JSON literal (single-bar form).
+fn parse_parameters(body: &str, dialect: DsmlDialect) -> serde_json::Map<String, Value> {
     let mut arguments = serde_json::Map::new();
     let mut rest = body;
-    while let Some(start) = rest.find(PARAM_OPEN) {
-        let header_start = start + PARAM_OPEN.len();
+    while let Some(start) = rest.find(dialect.marker) {
+        let header_start = start + dialect.marker.len();
         let Some(header_len) = unquoted_char(&rest[header_start..], '>') else {
             break;
         };
         let header = &rest[header_start..header_start + header_len];
-        let value_start = header_start + header_len + 1;
-        let Some(value_len) = rest[value_start..].find(PARAM_CLOSE) else {
+        let after_tag = header_start + header_len + 1;
+
+        let Some(tag) = header.split_whitespace().next() else {
             break;
         };
-        let raw = &rest[value_start..value_start + value_len];
+        // A closing tag (`</…invoke>`) means the enclosing element ended; the
+        // marker search cannot see `</` because the marker starts with `<`, so
+        // this only guards against a malformed header.
+        if tag.starts_with('/') {
+            rest = &rest[after_tag..];
+            continue;
+        }
+
+        if header.trim_end().ends_with('/') {
+            if let Some(name) = attribute(header, "name") {
+                let value = attribute(header, "string").unwrap_or_default();
+                arguments.insert(name.to_string(), Value::String(value.to_string()));
+            }
+            rest = &rest[after_tag..];
+            continue;
+        }
+
+        let close = format!("</{}{}>", dialect.marker.trim_start_matches('<'), tag);
+        let Some(value_len) = rest[after_tag..].find(&close) else {
+            break;
+        };
+        let raw = &rest[after_tag..after_tag + value_len];
         if let Some(name) = attribute(header, "name") {
             // string="false" marks a non-string JSON value (number, bool, ...).
             let value = if attribute(header, "string") == Some("false") {
@@ -105,7 +196,7 @@ fn parse_parameters(body: &str) -> serde_json::Map<String, Value> {
             };
             arguments.insert(name.to_string(), value);
         }
-        rest = &rest[value_start + value_len + PARAM_CLOSE.len()..];
+        rest = &rest[after_tag + value_len + close.len()..];
     }
     arguments
 }
@@ -150,7 +241,7 @@ pub(crate) fn synthesize_call_id() -> String {
 /// strip the markup from the visible text.
 pub fn heal_chat_message(message: &mut ChatMessage) {
     let text = message.text_content();
-    if !text.contains(DSML_MARKER) {
+    if detect_dialect(text).is_none() {
         return;
     }
     let Some((cleaned, calls)) = parse_leaked_tool_calls(text) else {
@@ -215,7 +306,7 @@ impl DsmlStreamFilter {
         if self.in_dsml {
             return String::new();
         }
-        if let Some(start) = self.pending.find(DSML_MARKER) {
+        if let Some((_, start)) = detect_dialect(&self.pending) {
             self.in_dsml = true;
             let emit = self.pending[..start].to_string();
             self.pending.drain(..start);
@@ -245,12 +336,19 @@ impl DsmlStreamFilter {
 }
 
 /// Length in bytes of the longest suffix of `text` that is a proper prefix of
-/// [`DSML_MARKER`].
+/// any dialect's marker.
+///
+/// Taking the maximum across dialects matters: `<｜` is a prefix of both, and
+/// withholding only the shorter one would emit the first bar of a double-bar
+/// marker before the rest of it arrives, splitting the marker across chunks so
+/// it never matches.
 fn longest_marker_prefix_suffix(text: &str) -> usize {
     let mut best = 0;
-    for (i, _) in DSML_MARKER.char_indices().skip(1) {
-        if text.ends_with(&DSML_MARKER[..i]) {
-            best = i;
+    for dialect in DIALECTS {
+        for (i, _) in dialect.marker.char_indices().skip(1) {
+            if text.ends_with(&dialect.marker[..i]) {
+                best = best.max(i);
+            }
         }
     }
     best
@@ -298,6 +396,80 @@ mod tests {
     fn plain_text_is_untouched() {
         assert!(parse_leaked_tool_calls("no markup here, just a < b").is_none());
         assert!(parse_leaked_tool_calls("<｜DSML｜tool_calls>dangling").is_none());
+        assert!(parse_leaked_tool_calls("<｜｜DSML｜｜tool_calls>dangling").is_none());
+    }
+
+    /// Verbatim capture from Codex 0.144.5 → relay → Command Code →
+    /// deepseek/deepseek-v4-flash, 2026-08-07. Doubled delimiters, and the
+    /// parameter is a self-closing `invoke` carrying its value in `string`.
+    const DOUBLE_BAR_ENVELOPE: &str = "<｜｜DSML｜｜tool_calls>\n<｜｜DSML｜｜invoke name=\"exec_command\">\n<｜｜DSML｜｜invoke name=\"cmd\" string=\"echo alpha\" />\n</｜｜DSML｜｜invoke>\n</｜｜DSML｜｜tool_calls>";
+
+    #[test]
+    fn parses_double_bar_envelope_with_self_closing_parameters() {
+        let text = format!("Let me run it.\n{DOUBLE_BAR_ENVELOPE}");
+        let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("healed");
+        assert_eq!(cleaned, "Let me run it.");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "exec_command");
+        let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert_eq!(args["cmd"], "echo alpha");
+    }
+
+    #[test]
+    fn double_bar_self_closing_parameter_keeps_special_characters() {
+        // Quotes inside the value would end the header scan early if the `>`
+        // search were not quote-aware; `/` inside it must not read as
+        // self-closing on its own either.
+        let text = "<｜｜DSML｜｜invoke name=\"exec_command\">\n<｜｜DSML｜｜invoke name=\"cmd\" string=\"grep -r a/b > out.txt\" />\n</｜｜DSML｜｜invoke>";
+        let (_, calls) = parse_leaked_tool_calls(text).expect("healed");
+        let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert_eq!(args["cmd"], "grep -r a/b > out.txt");
+    }
+
+    #[test]
+    fn double_bar_supports_bodied_parameters_too() {
+        // Not observed in the wild, but the dialect differs only in the
+        // delimiter; a bodied parameter must not silently drop its value.
+        let text = "<｜｜DSML｜｜invoke name=\"bash\">\n<｜｜DSML｜｜parameter name=\"command\" string=\"true\">ls -la</｜｜DSML｜｜parameter>\n<｜｜DSML｜｜parameter name=\"timeout\" string=\"false\">15</｜｜DSML｜｜parameter>\n</｜｜DSML｜｜invoke>";
+        let (_, calls) = parse_leaked_tool_calls(text).expect("healed");
+        let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert_eq!(args["command"], "ls -la");
+        assert_eq!(args["timeout"], 15);
+    }
+
+    #[test]
+    fn heal_chat_message_fires_on_double_bar() {
+        let mut message = ChatMessage {
+            role: "assistant".into(),
+            content: Some(Value::String(DOUBLE_BAR_ENVELOPE.to_string())),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+        };
+        heal_chat_message(&mut message);
+        let calls = message.tool_calls.expect("tool calls synthesized");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["function"]["name"], "exec_command");
+        assert!(message.content.is_none());
+    }
+
+    #[test]
+    fn stream_filter_holds_split_double_bar_marker_and_heals() {
+        let mut filter = DsmlStreamFilter::default();
+        let mut emitted = String::new();
+        // Split inside the doubled delimiter: withholding only a single-bar
+        // prefix here would leak "<｜" and desync the marker.
+        emitted.push_str(&filter.push("Let me run it.<｜"));
+        emitted.push_str(&filter.push("｜DSML｜｜tool_calls>\n<｜｜DSML｜｜invoke name=\"exec_command\">\n<｜｜DSML｜｜invoke name=\"cmd\" string=\"echo alpha\" />\n</｜｜DSML｜｜invoke>\n</｜｜DSML｜｜"));
+        emitted.push_str(&filter.push("tool_calls>"));
+        assert_eq!(emitted, "Let me run it.");
+        let (leftover, calls) = filter.finish();
+        assert_eq!(leftover, "");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "exec_command");
+        let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
+        assert_eq!(args["cmd"], "echo alpha");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`dsml_heal` only matched `<｜DSML｜…>`. `deepseek/deepseek-v4-flash` leaks a **doubled** delimiter, and expresses parameters as self-closing `invoke` tags whose value sits in the `string` attribute rather than in the tag body.

Verbatim capture, Codex 0.144.5 → relay → Command Code → `deepseek/deepseek-v4-flash`, 2026-08-07:

```
<｜｜DSML｜｜tool_calls>
<｜｜DSML｜｜invoke name="exec_command">
<｜｜DSML｜｜invoke name="cmd" string="echo alpha" />
</｜｜DSML｜｜invoke>
</｜｜DSML｜｜tool_calls>
```

Two differences from the dialect the module handles:

1. `<｜｜DSML｜｜` vs `<｜DSML｜` — the marker search misses entirely.
2. the parameter is a self-closing `invoke`, not a `parameter` with a body, and its value is the `string` attribute (in the single-bar dialect `string="true"/"false"` is a *type* marker, not the value).

So `parse_leaked_tool_calls` returned `None` and the raw markup reached Codex as assistant text: no tool ran and the turn stalled silently. Exactly the failure this module exists to prevent — but invisible, because healing simply never fired rather than firing and failing.

## Fix

Introduce a `DsmlDialect` carrying both delimiter flavours; pick the one whose marker appears earliest in the text.

Parameters are now read **by shape rather than by tag name**, since the two dialects disagree on the name (`parameter` vs `invoke`) but agree on structure:

- self-closing (`… />`) — no body exists, so the value can only be the `string` attribute;
- with a body — value is the body text, `string="false"` marks a non-string JSON literal (existing behaviour, unchanged).

`longest_marker_prefix_suffix` now takes the maximum across dialects. `<｜` is a prefix of both; withholding only the shorter one would emit the first bar of a double-bar marker before the rest arrived, splitting the marker across chunks so it never matched.

## Verification

Real-traffic leaks are intermittent (as the module docs note), so I did not rely on catching one. A stub upstream that always returns the captured markup, driven through the full relay path:

| path | result |
|---|---|
| blocking | `function_call` `name=exec_command` `arguments={"cmd":"echo alpha"}` |
| streaming, emitted **one character at a time** | same call synthesized correctly |

`quirk dsml_heal fired` in both. The per-character streaming case is deliberate: it splits the doubled delimiter across as many chunks as possible.

## Tests

5 new tests, including the verbatim capture above, a value containing `/`, `>` and quotes, a bodied parameter in the double-bar dialect, `heal_chat_message` end to end, and a stream split *inside* the doubled delimiter. All existing single-bar tests are untouched and still pass.

## Note

I have one captured sample of this dialect. The self-closing/bodied split is inferred from structure rather than from a spec, so if you know the actual grammar and it disagrees, say so and I will adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)