### PR TITLE
chore: restore quality gate baseline

### DIFF
--- a/src/corpus.rs
+++ b/src/corpus.rs
@@ -189,7 +189,10 @@ mod tests {
     use uuid::Uuid;
 
     fn temp_dir(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("codex-relay-corpus-{name}-{}", Uuid::new_v4().simple()));
+        let dir = std::env::temp_dir().join(format!(
+            "codex-relay-corpus-{name}-{}",
+            Uuid::new_v4().simple()
+        ));
         fs::create_dir_all(&dir).unwrap();
         dir
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -831,7 +831,9 @@ async fn handle_blocking(
                         &full_history,
                     );
                 }
-                state.sessions.save_with_id(response_id.clone(), full_history);
+                state
+                    .sessions
+                    .save_with_id(response_id.clone(), full_history);
 
                 let (resp, _) = if namespace_tools.is_empty() && custom_tools.is_empty() {
                     translate::from_chat_response(response_id, &model, chat_resp)

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,6 +33,9 @@ pub enum ResponsesInput {
     Messages(Vec<Value>),
 }
 
+// Public compatibility type. The binary compiles this module directly but
+// does not construct content parts itself, so it appears unused there.
+#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct ContentPart {
     #[serde(rename = "type")]


### PR DESCRIPTION
## Summary
- preserve the public ContentPart compatibility type while suppressing the binary-only dead-code diagnostic
- apply existing rustfmt drift in corpus and blocking response handling

## Verification
- cargo test
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings