### PR TITLE
fix: harden malformed DSML recovery

### DIFF
--- a/src/dsml.rs
+++ b/src/dsml.rs
@@ -112,12 +112,10 @@ pub fn parse_leaked_tool_calls(text: &str) -> Option<(String, Vec<DsmlToolCall>)
     while let Some((dialect, start)) = find_next_invoke(text, search_from) {
         match parse_invoke(text, start, dialect) {
             Ok((end, call)) => {
-                let removal_start = envelope_start(text, copied_through, start, dialect);
-                let removal_end = envelope_end(text, end, dialect);
-                cleaned.push_str(&text[copied_through..removal_start]);
+                cleaned.push_str(&text[copied_through..start]);
                 calls.push(call);
-                copied_through = removal_end;
-                search_from = removal_end;
+                copied_through = end;
+                search_from = end;
             }
             Err(()) => {
                 // Preserve malformed candidates byte-for-byte, but continue so
@@ -134,7 +132,7 @@ pub fn parse_leaked_tool_calls(text: &str) -> Option<(String, Vec<DsmlToolCall>)
         return None;
     }
     cleaned.push_str(&text[copied_through..]);
-    Some((cleaned.trim().to_string(), calls))
+    Some((strip_empty_envelopes(cleaned), calls))
 }
 
 #[derive(Debug)]
@@ -255,19 +253,37 @@ fn parse_invoke(
 /// Find the balanced end of a malformed invoke so recovery never descends
 /// into a nested, valid-looking call and executes it out of context.
 fn malformed_invoke_end(text: &str, start: usize, dialect: DsmlDialect) -> Option<usize> {
-    let outer = parse_open_tag(text, start, dialect).ok()?;
+    let outer = scan_open_tag(text, start, dialect)?;
     if outer.name != "invoke" || outer.self_closing {
         return Some(outer.end);
     }
     let mut depth = 1usize;
     let mut cursor = outer.end;
     while cursor < text.len() {
+        let next_foreign_open = DIALECTS
+            .iter()
+            .filter(|candidate| **candidate != dialect)
+            .filter_map(|candidate| {
+                text[cursor..]
+                    .find(candidate.marker)
+                    .map(|offset| cursor + offset)
+            })
+            .min();
         let next_open = text[cursor..]
             .find(dialect.marker)
             .map(|offset| cursor + offset);
         let next_close = text[cursor..]
             .find(dialect.invoke_close)
             .map(|offset| cursor + offset);
+        let next_current = next_open.into_iter().chain(next_close).min();
+        if next_foreign_open
+            .is_some_and(|foreign| next_current.is_none_or(|current| foreign < current))
+        {
+            // Mixed-dialect structure inside a malformed invoke cannot be
+            // balanced by this dialect's stack. Stop rather than recovering
+            // at a forged close and exposing the foreign nested call.
+            return None;
+        }
         match (next_open, next_close) {
             (None, Some(close)) => {
                 depth -= 1;
@@ -284,13 +300,75 @@ fn malformed_invoke_end(text: &str, start: usize, dialect: DsmlDialect) -> Optio
                 }
             }
             (Some(open), _) => {
-                let tag = parse_open_tag(text, open, dialect).ok()?;
+                let tag = scan_open_tag(text, open, dialect)?;
                 if tag.name == "invoke" && !tag.self_closing {
                     depth += 1;
+                } else if tag.name == "parameter" && !tag.self_closing {
+                    let close = parameter_close(dialect);
+                    let tail = &text[tag.end..];
+                    let close_offset = tail.find(&close)?;
+                    // A nested opening tag makes the parameter boundary
+                    // ambiguous. Stop recovery rather than borrowing its
+                    // closing tag and exposing a nested call for execution.
+                    if tail
+                        .find(dialect.marker)
+                        .is_some_and(|offset| offset < close_offset)
+                    {
+                        return None;
+                    }
+                    cursor = tag.end + close_offset + close.len();
+                    continue;
                 }
                 cursor = tag.end;
             }
             (None, None) => return None,
+        }
+    }
+    None
+}
+
+/// Locate a tag boundary without accepting its attributes. Recovery needs to
+/// skip a malformed candidate before looking for a later sibling, but using
+/// the strict parser here would make a bounded error such as `name=bad` stop
+/// all scanning. Unclosed quotes remain unbounded and therefore fail closed.
+fn scan_open_tag(text: &str, start: usize, dialect: DsmlDialect) -> Option<ParsedTag> {
+    if !text[start..].starts_with(dialect.marker) {
+        return None;
+    }
+    let mut cursor = start + dialect.marker.len();
+    let name_start = cursor;
+    while let Some(ch) = text[cursor..].chars().next() {
+        if ch.is_whitespace() || matches!(ch, '/' | '>') {
+            break;
+        }
+        cursor += ch.len_utf8();
+    }
+    if cursor == name_start {
+        return None;
+    }
+    let name = text[name_start..cursor].to_string();
+    let mut quoted = false;
+    let mut escaped = false;
+    while let Some(ch) = text[cursor..].chars().next() {
+        cursor += ch.len_utf8();
+        if quoted {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                quoted = false;
+            }
+        } else if ch == '"' {
+            quoted = true;
+        } else if ch == '>' {
+            let before = text[..cursor - 1].trim_end();
+            return Some(ParsedTag {
+                name,
+                attrs: BTreeMap::new(),
+                self_closing: before.ends_with('/'),
+                end: cursor,
+            });
         }
     }
     None
@@ -370,6 +448,13 @@ fn parse_open_tag(text: &str, start: usize, dialect: DsmlDialect) -> Result<Pars
         if attrs.insert(key, value).is_some() {
             return Err(());
         }
+        if text[cursor..]
+            .chars()
+            .next()
+            .is_some_and(|ch| !ch.is_whitespace() && !matches!(ch, '/' | '>'))
+        {
+            return Err(());
+        }
     }
 }
 
@@ -404,25 +489,39 @@ fn skip_whitespace(text: &str, mut cursor: usize) -> usize {
     cursor
 }
 
-fn envelope_start(
-    text: &str,
-    copied_through: usize,
-    invoke_start: usize,
-    dialect: DsmlDialect,
-) -> usize {
-    let prefix = &text[copied_through..invoke_start];
-    prefix
-        .rfind(dialect.calls_open)
-        .filter(|at| prefix[at + dialect.calls_open.len()..].trim().is_empty())
-        .map_or(invoke_start, |at| copied_through + at)
+fn parameter_close(dialect: DsmlDialect) -> String {
+    format!("</{}parameter>", dialect.marker.trim_start_matches('<'))
 }
 
-fn envelope_end(text: &str, invoke_end: usize, dialect: DsmlDialect) -> usize {
-    let after_whitespace = skip_whitespace(text, invoke_end);
-    if text[after_whitespace..].starts_with(dialect.calls_close) {
-        after_whitespace + dialect.calls_close.len()
-    } else {
-        invoke_end
+/// Remove only matched envelope pairs whose contents became empty after all
+/// successfully parsed invokes were removed. If malformed markup remains,
+/// both wrappers stay intact rather than deleting only one side.
+fn strip_empty_envelopes(mut text: String) -> String {
+    loop {
+        let mut removed = false;
+        for dialect in DIALECTS {
+            let mut search_from = 0;
+            while let Some(open_offset) = text[search_from..].find(dialect.calls_open) {
+                let open = search_from + open_offset;
+                let inner = open + dialect.calls_open.len();
+                let Some(close_offset) = text[inner..].find(dialect.calls_close) else {
+                    break;
+                };
+                let close = inner + close_offset;
+                if text[inner..close].trim().is_empty() {
+                    text.replace_range(open..close + dialect.calls_close.len(), "");
+                    removed = true;
+                    break;
+                }
+                search_from = close + dialect.calls_close.len();
+            }
+            if removed {
+                break;
+            }
+        }
+        if !removed {
+            return text;
+        }
     }
 }
 
@@ -558,7 +657,7 @@ mod tests {
     fn parses_leaked_envelope() {
         let text = format!("我来读取文件。\n{ENVELOPE}");
         let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("healed");
-        assert_eq!(cleaned, "我来读取文件。");
+        assert_eq!(cleaned, "我来读取文件。\n");
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "shell");
         let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
@@ -602,7 +701,7 @@ mod tests {
     fn parses_double_bar_envelope_with_self_closing_parameters() {
         let text = format!("Let me run it.\n{DOUBLE_BAR_ENVELOPE}");
         let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("healed");
-        assert_eq!(cleaned, "Let me run it.");
+        assert_eq!(cleaned, "Let me run it.\n");
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "exec_command");
         let args: Value = serde_json::from_str(&calls[0].arguments).unwrap();
@@ -649,7 +748,7 @@ mod tests {
             format!("{DOUBLE_BAR_ENVELOPE}\n{ENVELOPE}"),
         ] {
             let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("healed");
-            assert_eq!(cleaned, "");
+            assert_eq!(cleaned, "\n");
             assert_eq!(calls.len(), 2);
             if text.starts_with("<｜DSML｜") {
                 assert_eq!(calls[0].name, "shell");
@@ -666,7 +765,7 @@ mod tests {
         let malformed = "<｜DSML｜invoke_extra name=\"not_a_call\">raw</｜DSML｜invoke_extra>";
         let text = format!("{malformed}\n{DOUBLE_BAR_ENVELOPE}");
         let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("later call healed");
-        assert_eq!(cleaned, malformed);
+        assert_eq!(cleaned, format!("{malformed}\n"));
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "exec_command");
     }
@@ -695,7 +794,7 @@ mod tests {
             "<｜｜DSML｜｜invoke name=\"bad\"><｜｜DSML｜｜invoke name=\"cmd\" /></｜｜DSML｜｜invoke>";
         let text = format!("{malformed}\n{ENVELOPE}");
         let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("later call healed");
-        assert_eq!(cleaned, malformed);
+        assert_eq!(cleaned, format!("{malformed}\n"));
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "shell");
     }
@@ -705,9 +804,103 @@ mod tests {
         let malformed = "<｜｜DSML｜｜invoke name=\"bad\">\n<｜｜DSML｜｜invoke name=\"exec_command\">\n<｜｜DSML｜｜invoke name=\"cmd\" string=\"echo bad\" />\n</｜｜DSML｜｜invoke>\n</｜｜DSML｜｜invoke>";
         let text = format!("{malformed}\n{ENVELOPE}");
         let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("later sibling healed");
-        assert_eq!(cleaned, malformed);
+        assert_eq!(cleaned, format!("{malformed}\n"));
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "shell");
+    }
+
+    #[test]
+    fn invoke_close_inside_parameter_cannot_expose_nested_call() {
+        let malformed = "<｜DSML｜invoke name=\"bad\">\n<｜DSML｜parameter name=\"x\" string=\"true\">literal </｜DSML｜invoke></｜DSML｜parameter>\n<｜DSML｜invoke name=\"shell\">\n<｜DSML｜parameter name=\"command\" string=\"true\">echo bad</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜invoke>";
+        assert!(parse_leaked_tool_calls(malformed).is_none());
+
+        let text = format!("{malformed}\n{ENVELOPE}");
+        let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("later sibling healed");
+        assert!(cleaned.starts_with(malformed));
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "shell");
+    }
+
+    #[test]
+    fn foreign_dialect_parameter_cannot_expose_nested_call() {
+        let cases = [
+            "<｜DSML｜invoke name=\"bad\"><｜｜DSML｜｜parameter name=\"x\" string=\"true\">literal </｜DSML｜invoke></｜｜DSML｜｜parameter><｜｜DSML｜｜invoke name=\"exec_command\"><｜｜DSML｜｜invoke name=\"cmd\" string=\"echo bad\" /></｜｜DSML｜｜invoke></｜DSML｜invoke>",
+            "<｜｜DSML｜｜invoke name=\"bad\"><｜DSML｜parameter name=\"x\" string=\"true\">literal </｜｜DSML｜｜invoke></｜DSML｜parameter><｜DSML｜invoke name=\"shell\"><｜DSML｜parameter name=\"command\" string=\"true\">echo bad</｜DSML｜parameter></｜DSML｜invoke></｜｜DSML｜｜invoke>",
+        ];
+        for malformed in cases {
+            assert!(
+                parse_leaked_tool_calls(malformed).is_none(),
+                "foreign nested call must not execute: {malformed}"
+            );
+        }
+    }
+
+    #[test]
+    fn attributes_require_whitespace_separators() {
+        for malformed in [
+            "<｜DSML｜invoke name=\"shell\"><｜DSML｜parameter name=\"command\"string=\"true\">echo bad</｜DSML｜parameter></｜DSML｜invoke>",
+            "<｜｜DSML｜｜invoke name=\"exec_command\"><｜｜DSML｜｜invoke name=\"cmd\"string=\"echo bad\" /></｜｜DSML｜｜invoke>",
+        ] {
+            assert!(parse_leaked_tool_calls(malformed).is_none());
+        }
+    }
+
+    #[test]
+    fn bounded_malformed_open_tag_does_not_block_later_sibling() {
+        let malformed = "<｜｜DSML｜｜invoke name=bad></｜｜DSML｜｜invoke>";
+        let text = format!("{malformed}\n{ENVELOPE}");
+        let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("later sibling healed");
+        assert!(cleaned.starts_with(malformed));
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "shell");
+    }
+
+    #[test]
+    fn unbounded_malformed_open_tag_fails_closed() {
+        let malformed = "<｜｜DSML｜｜invoke name=\"unterminated></｜｜DSML｜｜invoke>";
+        let text = format!("{malformed}\n{ENVELOPE}");
+        assert!(parse_leaked_tool_calls(&text).is_none());
+    }
+
+    #[test]
+    fn mixed_validity_envelope_keeps_both_wrappers() {
+        let valid = "<｜｜DSML｜｜invoke name=\"exec_command\"><｜｜DSML｜｜invoke name=\"cmd\" string=\"echo good\" /></｜｜DSML｜｜invoke>";
+        let malformed = "<｜｜DSML｜｜invoke name=\"bad\"><｜｜DSML｜｜metadata name=\"x\" /></｜｜DSML｜｜invoke>";
+        for body in [
+            format!("{valid}\n{malformed}"),
+            format!("{malformed}\n{valid}"),
+        ] {
+            let text = format!("<｜｜DSML｜｜tool_calls>\n{body}\n</｜｜DSML｜｜tool_calls>");
+            let (cleaned, calls) = parse_leaked_tool_calls(&text).expect("valid call healed");
+            assert!(cleaned.contains("<｜｜DSML｜｜tool_calls>"));
+            assert!(cleaned.contains("</｜｜DSML｜｜tool_calls>"));
+            assert!(cleaned.contains(malformed));
+            assert_eq!(calls.len(), 1);
+        }
+    }
+
+    #[test]
+    fn blocking_and_streaming_visible_text_match() {
+        for (prefix, expected) in [("prefix\n", "prefix\n"), ("\n", "\n")] {
+            let text = format!("{prefix}{ENVELOPE}");
+            let (blocking, blocking_calls) =
+                parse_leaked_tool_calls(&text).expect("blocking healed");
+            assert_eq!(blocking, expected);
+
+            for split in text
+                .char_indices()
+                .map(|(at, _)| at)
+                .chain(std::iter::once(text.len()))
+            {
+                let mut filter = DsmlStreamFilter::default();
+                let mut streamed = filter.push(&text[..split]);
+                streamed.push_str(&filter.push(&text[split..]));
+                let (leftover, calls) = filter.finish();
+                streamed.push_str(&leftover);
+                assert_eq!(streamed, blocking, "split at byte {split}");
+                assert_eq!(calls, blocking_calls, "split at byte {split}");
+            }
+        }
     }
 
     #[test]
@@ -760,7 +953,7 @@ mod tests {
             emitted.push_str(&filter.push(&ch.to_string()));
         }
         let (leftover, calls) = filter.finish();
-        assert_eq!(format!("{emitted}{leftover}"), "prefix\n");
+        assert_eq!(format!("{emitted}{leftover}"), "prefix\n\n");
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].name, "shell");
         assert_eq!(calls[1].name, "exec_command");
@@ -829,7 +1022,7 @@ mod tests {
             name: None,
         };
         heal_chat_message(&mut message);
-        assert_eq!(message.text_content(), "我来逐步完成这个任务。");
+        assert_eq!(message.text_content(), "我来逐步完成这个任务。\n");
         let tool_calls = message.tool_calls.as_ref().expect("healed tool_calls");
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0]["function"]["name"], "shell");

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -363,7 +363,7 @@ fn dsml_leak_blocking_response_heals_into_function_call() {
     assert_eq!(response.output[0]["type"], "message");
     assert_eq!(
         response.output[0]["content"][0]["text"],
-        "我来逐步完成这个任务。"
+        "我来逐步完成这个任务。\n"
     );
     let call = &response.output[1];
     assert_eq!(call["type"], "function_call");
@@ -375,7 +375,7 @@ fn dsml_leak_blocking_response_heals_into_function_call() {
     );
 
     // Session history must store the healed message, not the raw markup.
-    assert_eq!(history[0].text_content(), "我来逐步完成这个任务。");
+    assert_eq!(history[0].text_content(), "我来逐步完成这个任务。\n");
     assert_eq!(history[0].tool_calls.as_ref().unwrap().len(), 1);
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #49 after a security-focused Oracle review.

- fail closed when malformed invokes contain forged closing tags or mixed-dialect nested structure
- require whitespace between DSML attributes
- recover past bounded malformed candidates while stopping on ambiguous boundaries
- preserve paired tool-call envelopes around malformed siblings
- make blocking and streaming visible text chunk-invariant without global trimming

## Verification

- 
running 124 tests
test corpus::tests::civil_from_days_matches_known_dates ... ok
test dsml::tests::disabled_stream_filter_passes_markup_through ... ok
test dsml::tests::attributes_require_whitespace_separators ... ok
test dsml::tests::bounded_malformed_open_tag_does_not_block_later_sibling ... ok
test dsml::tests::double_bar_attribute_parser_handles_escapes_and_tag_text ... ok
test dsml::tests::double_bar_self_closing_parameter_keeps_special_characters ... ok
test dsml::tests::foreign_dialect_parameter_cannot_expose_nested_call ... ok
test dsml::tests::double_bar_supports_bodied_parameters_too ... ok
test dsml::tests::heal_chat_message_moves_markup_into_tool_calls ... ok
test dsml::tests::heal_chat_message_fires_on_double_bar ... ok
test dsml::tests::invoke_close_inside_parameter_cannot_expose_nested_call ... ok
test corpus::tests::isolated_child_with_unknown_parent_starts_new_conversation ... ok
test dsml::tests::malformed_call_is_preserved_when_later_call_heals ... ok
test dsml::tests::malformed_calls_fail_closed ... ok
test dsml::tests::malformed_marker_does_not_block_later_valid_dialect ... ok
test dsml::tests::parses_double_bar_envelope_with_self_closing_parameters ... ok
test dsml::tests::mixed_validity_envelope_keeps_both_wrappers ... ok
test dsml::tests::nested_call_inside_malformed_invoke_never_executes ... ok
test dsml::tests::parses_leaked_envelope ... ok
test dsml::tests::parses_multiline_and_nonstring_parameters ... ok
test dsml::tests::plain_text_is_untouched ... ok
test corpus::tests::preserves_tool_calls_and_reasoning ... ok
test dsml::tests::parses_mixed_dialects_in_source_order ... ok
test dsml::tests::parses_multiple_invokes ... ok
test corpus::tests::records_only_delta_on_continued_turn ... ok
test dsml::tests::stream_filter_holds_split_double_bar_marker_and_heals ... ok
test corpus::tests::records_full_conversation_on_first_turn ... ok
test dsml::tests::stream_filter_passes_incomplete_markup_through ... ok
test dsml::tests::stream_filter_holds_split_marker_and_heals ... ok
test dsml::tests::stream_filter_passes_plain_text ... ok
test dsml::tests::stream_filter_handles_mixed_dialects_one_character_at_a_time ... ok
test dsml::tests::stream_filter_releases_false_marker_prefix ... ok
test dsml::tests::unclosed_parameter_cannot_borrow_close_from_nested_call ... ok
test dsml::tests::unbounded_malformed_open_tag_fails_closed ... ok
test quirks::tests::glm_like_model_matching ... ok
test session::tests::test_cleanup_removes_expired_reasoning ... ok
test session::tests::test_content_key_deterministic ... ok
test quirks::tests::parses_disable_list ... ok
test session::tests::test_cleanup_removes_expired_session ... ok
test session::tests::test_empty_reasoning_not_stored ... ok
test session::tests::test_get_reasoning_missing ... ok
test session::tests::test_evicts_oldest_session_by_count ... ok
test session::tests::test_evicts_oldest_session_by_bytes ... ok
test session::tests::test_history_save_and_get ... ok
test session::tests::test_oversized_session_not_cached ... ok
test session::tests::test_reasoning_entries_are_bounded_by_bytes ... ok
test session::tests::test_store_and_get_reasoning ... ok
test session::tests::test_turn_reasoning_also_stores_call_ids ... ok
test session::tests::test_turn_reasoning_by_content ... ok
test session::tests::test_turn_reasoning_empty_content ... ok
test think::tests::close_tag_after_visible_text_is_not_reasoning ... ok
test think::tests::disabled_filter_passes_markup_through ... ok
test think::tests::heals_blocking_message ... ok
test think::tests::explicit_tags_are_chunk_invariant ... ok
test think::tests::heals_blocking_message_with_prefilled_open_tag ... ok
test think::tests::kimi_markers_are_recognized ... ok
test think::tests::passes_plain_text_through_untouched ... ok
test think::tests::preserves_plain_text_leading_whitespace ... ok
test think::tests::preserves_whitespace_around_mid_message_think_block ... ok
test think::tests::recognizes_tags_split_across_deltas ... ok
test think::tests::removes_empty_blocking_think_block ... ok
test think::tests::splits_a_complete_think_block ... ok
test think::tests::unterminated_think_block_stays_reasoning ... ok
test think::tests::streaming_bare_close_tag_is_chunk_invariant_visible_text ... ok
test translate::tests::test_absent_reasoning_omits_the_field ... ok
test translate::tests::test_agent_message_plaintext_input_reaches_chat_upstream ... ok
test translate::tests::test_all_blank_messages_keep_only_the_newest ... ok
test translate::tests::test_assistant_message_with_tool_calls_and_no_content_is_kept ... ok
test translate::tests::test_blank_developer_input_does_not_replace_instructions ... ok
test translate::tests::test_blank_history_system_does_not_suppress_instructions ... ok
test translate::tests::test_blank_instructions_fall_back_to_system ... ok
test translate::tests::test_blank_messages_do_not_split_parallel_tool_calls ... ok
test translate::tests::test_blank_user_message_in_history_is_dropped ... ok
test translate::tests::test_convert_tool_already_nested ... ok
test translate::tests::test_chat_style_image_url_passes_through ... ok
test translate::tests::test_convert_tool_flat_to_nested ... ok
test translate::tests::test_convert_tools_preserves_subagent_tools_without_denylist ... ok
test translate::tests::test_convert_tools_denylist_filters_flat_and_namespaced_tools ... ok
test translate::tests::test_collaboration_calls_request_plaintext_arguments ... ok
test translate::tests::test_custom_tool_call_and_output_replay_as_chat_messages ... ok
test translate::tests::test_developer_role_mapped_to_system ... ok
test translate::tests::test_explicit_null_reasoning_deserializes_to_none ... ok
test translate::tests::test_from_chat_response_keeps_legacy_dot_namespace_split ... ok
test translate::tests::test_from_chat_response_keeps_legacy_non_namespaced_tool_name ... ok
test session::tests::test_disk_store_ignores_corrupt_session_file ... ok
test translate::tests::test_from_chat_response_preserves_hyphen_flat_tool_name ... ok
test translate::tests::test_from_chat_response_uses_request_tool_map_for_namespace ... ok
test translate::tests::test_function_call_output_becomes_tool_message ... ok
test translate::tests::test_function_call_grouping ... ok
test translate::tests::test_image_only_message_is_kept ... ok
test translate::tests::test_map_model_name_no_env_var ... ok
test translate::tests::test_input_image_becomes_multimodal_content ... ok
test translate::tests::test_map_model_name_no_match_passthrough ... ok
test translate::tests::test_map_model_name_with_env ... ok
test translate::tests::test_map_model_name_trims_whitespace ... ok
test translate::tests::test_never_empties_the_message_array ... ok
test translate::tests::test_namespaced_function_call_replays_to_flattened_chat_name ... ok
test translate::tests::test_null_user_message_is_dropped ... ok
test translate::tests::test_reasoning_without_effort_forwards_nothing ... ok
test translate::tests::test_reasoning_effort_is_forwarded_verbatim ... ok
test translate::tests::test_skip_duplicate_function_call_from_history ... ok
test translate::tests::test_system_from_input_replaces_instructions ... ok
test translate::tests::test_system_message_at_start_of_input ... ok
test translate::tests::test_skip_duplicate_function_call_output_from_history ... ok
test translate::tests::test_system_prompt_from_instructions ... ok
test translate::tests::test_system_message_between_tool_calls_moved_to_front ... ok
test translate::tests::test_text_input_becomes_user_message ... ok
test translate::tests::test_text_only_parts_collapse_to_string ... ok
test translate::tests::test_to_chat_request_honors_tool_denylist_env ... ok
test translate::tests::test_value_to_text_string ... ok
test translate::tests::test_value_to_text_parts_array ... ok
test types::tests::cache_summary_handles_missing_usage_fields ... ok
test translate::tests::test_whitespace_only_user_message_is_dropped ... ok
test types::tests::cache_summary_prefers_top_level_hit_when_both_shapes_exist ... ok
test types::tests::cache_summary_uses_deepseek_top_level_cache_fields ... ok
test types::tests::cache_summary_uses_openai_prompt_tokens_details ... ok
test session::tests::test_disk_store_reasoning_across_instances ... ok
test upstream_request::tests::rejects_non_object_extra_params ... ok
test upstream_request::tests::merges_extra_params_and_drops_top_level_params ... ok
test session::tests::test_disk_store_save_load_history_across_instances ... ok
test upstream_request::tests::rejects_non_string_drop_params ... ok
test session::tests::test_disk_store_turn_reasoning_across_instances ... ok
test session::tests::test_disk_store_evicts_files_by_count ... ok
test dsml::tests::blocking_and_streaming_visible_text_match ... ok

test result: ok. 124 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 142 tests
test corpus::tests::civil_from_days_matches_known_dates ... ok
test dsml::tests::disabled_stream_filter_passes_markup_through ... ok
test dsml::tests::double_bar_self_closing_parameter_keeps_special_characters ... ok
test dsml::tests::double_bar_attribute_parser_handles_escapes_and_tag_text ... ok
test dsml::tests::attributes_require_whitespace_separators ... ok
test dsml::tests::bounded_malformed_open_tag_does_not_block_later_sibling ... ok
test dsml::tests::double_bar_supports_bodied_parameters_too ... ok
test dsml::tests::foreign_dialect_parameter_cannot_expose_nested_call ... ok
test corpus::tests::isolated_child_with_unknown_parent_starts_new_conversation ... ok
test dsml::tests::heal_chat_message_fires_on_double_bar ... ok
test dsml::tests::heal_chat_message_moves_markup_into_tool_calls ... ok
test dsml::tests::malformed_call_is_preserved_when_later_call_heals ... ok
test corpus::tests::preserves_tool_calls_and_reasoning ... ok
test dsml::tests::malformed_marker_does_not_block_later_valid_dialect ... ok
test dsml::tests::malformed_calls_fail_closed ... ok
test dsml::tests::invoke_close_inside_parameter_cannot_expose_nested_call ... ok
test dsml::tests::mixed_validity_envelope_keeps_both_wrappers ... ok
test dsml::tests::parses_double_bar_envelope_with_self_closing_parameters ... ok
test dsml::tests::nested_call_inside_malformed_invoke_never_executes ... ok
test corpus::tests::records_full_conversation_on_first_turn ... ok
test dsml::tests::parses_leaked_envelope ... ok
test dsml::tests::plain_text_is_untouched ... ok
test dsml::tests::parses_multiline_and_nonstring_parameters ... ok
test dsml::tests::stream_filter_holds_split_double_bar_marker_and_heals ... ok
test dsml::tests::stream_filter_passes_plain_text ... ok
test dsml::tests::parses_multiple_invokes ... ok
test dsml::tests::stream_filter_passes_incomplete_markup_through ... ok
test corpus::tests::records_only_delta_on_continued_turn ... ok
test dsml::tests::stream_filter_holds_split_marker_and_heals ... ok
test dsml::tests::stream_filter_releases_false_marker_prefix ... ok
test dsml::tests::unbounded_malformed_open_tag_fails_closed ... ok
test quirks::tests::glm_like_model_matching ... ok
test dsml::tests::unclosed_parameter_cannot_borrow_close_from_nested_call ... ok
test session::tests::test_cleanup_removes_expired_reasoning ... ok
test session::tests::test_cleanup_removes_expired_session ... ok
test quirks::tests::parses_disable_list ... ok
test dsml::tests::parses_mixed_dialects_in_source_order ... ok
test session::tests::test_content_key_deterministic ... ok
test session::tests::test_empty_reasoning_not_stored ... ok
test session::tests::test_evicts_oldest_session_by_count ... ok
test dsml::tests::stream_filter_handles_mixed_dialects_one_character_at_a_time ... ok
test session::tests::test_evicts_oldest_session_by_bytes ... ok
test session::tests::test_get_reasoning_missing ... ok
test session::tests::test_history_save_and_get ... ok
test session::tests::test_oversized_session_not_cached ... ok
test session::tests::test_reasoning_entries_are_bounded_by_bytes ... ok
test session::tests::test_store_and_get_reasoning ... ok
test session::tests::test_turn_reasoning_also_stores_call_ids ... ok
test session::tests::test_turn_reasoning_by_content ... ok
test session::tests::test_turn_reasoning_empty_content ... ok
test tests::test_chat_response_tool_call_debug_names_do_not_include_arguments ... ok
test tests::test_estimate_model_properties_deepseek ... ok
test tests::test_estimate_model_properties_deepseek_r1 ... ok
test tests::test_estimate_model_properties_unknown ... ok
test tests::test_join_base_adds_trailing_slash ... ok
test tests::test_join_base_preserves_trailing_slash ... ok
test tests::test_response_tool_debug_names_include_flat_and_namespace_tools ... ok
test tests::test_spawn_child_isolation_does_not_match_tool_outputs ... ok
test tests::test_spawn_child_isolation_ignores_completed_spawn_calls ... ok
test tests::test_spawn_child_request_isolated_for_single_v2_encrypted_spawn ... ok
test tests::test_spawn_child_request_isolated_when_input_matches_spawn_message ... ok
test tests::test_validate_upstream_http_localhost ... ok
test tests::test_spawn_child_v2_encrypted_fallback_requires_unambiguous_spawn ... ok
test tests::test_validate_upstream_https ... ok
test tests::test_validate_upstream_rejects_file ... ok
test tests::test_validate_upstream_rejects_ftp ... ok
test tests::test_validate_upstream_rejects_garbage ... ok
test tests::test_validate_upstream_trailing_slash_stripped ... ok
test think::tests::close_tag_after_visible_text_is_not_reasoning ... ok
test think::tests::disabled_filter_passes_markup_through ... ok
test think::tests::explicit_tags_are_chunk_invariant ... ok
test think::tests::heals_blocking_message ... ok
test think::tests::heals_blocking_message_with_prefilled_open_tag ... ok
test think::tests::kimi_markers_are_recognized ... ok
test think::tests::passes_plain_text_through_untouched ... ok
test think::tests::preserves_whitespace_around_mid_message_think_block ... ok
test think::tests::preserves_plain_text_leading_whitespace ... ok
test think::tests::recognizes_tags_split_across_deltas ... ok
test think::tests::removes_empty_blocking_think_block ... ok
test think::tests::splits_a_complete_think_block ... ok
test think::tests::streaming_bare_close_tag_is_chunk_invariant_visible_text ... ok
test think::tests::unterminated_think_block_stays_reasoning ... ok
test translate::tests::test_absent_reasoning_omits_the_field ... ok
test translate::tests::test_all_blank_messages_keep_only_the_newest ... ok
test translate::tests::test_agent_message_plaintext_input_reaches_chat_upstream ... ok
test translate::tests::test_assistant_message_with_tool_calls_and_no_content_is_kept ... ok
test translate::tests::test_blank_developer_input_does_not_replace_instructions ... ok
test session::tests::test_disk_store_ignores_corrupt_session_file ... ok
test translate::tests::test_blank_history_system_does_not_suppress_instructions ... ok
test translate::tests::test_blank_instructions_fall_back_to_system ... ok
test translate::tests::test_blank_user_message_in_history_is_dropped ... ok
test translate::tests::test_blank_messages_do_not_split_parallel_tool_calls ... ok
test translate::tests::test_chat_style_image_url_passes_through ... ok
test translate::tests::test_convert_tool_already_nested ... ok
test translate::tests::test_collaboration_calls_request_plaintext_arguments ... ok
test translate::tests::test_convert_tool_flat_to_nested ... ok
test translate::tests::test_convert_tools_denylist_filters_flat_and_namespaced_tools ... ok
test translate::tests::test_convert_tools_preserves_subagent_tools_without_denylist ... ok
test translate::tests::test_developer_role_mapped_to_system ... ok
test translate::tests::test_custom_tool_call_and_output_replay_as_chat_messages ... ok
test translate::tests::test_explicit_null_reasoning_deserializes_to_none ... ok
test translate::tests::test_from_chat_response_keeps_legacy_dot_namespace_split ... ok
test translate::tests::test_from_chat_response_keeps_legacy_non_namespaced_tool_name ... ok
test translate::tests::test_from_chat_response_preserves_hyphen_flat_tool_name ... ok
test session::tests::test_disk_store_evicts_files_by_count ... ok
test translate::tests::test_from_chat_response_uses_request_tool_map_for_namespace ... ok
test translate::tests::test_function_call_output_becomes_tool_message ... ok
test translate::tests::test_function_call_grouping ... ok
test translate::tests::test_map_model_name_no_env_var ... ok
test translate::tests::test_input_image_becomes_multimodal_content ... ok
test translate::tests::test_image_only_message_is_kept ... ok
test session::tests::test_disk_store_reasoning_across_instances ... ok
test translate::tests::test_map_model_name_no_match_passthrough ... ok
test translate::tests::test_map_model_name_trims_whitespace ... ok
test translate::tests::test_map_model_name_with_env ... ok
test translate::tests::test_namespaced_function_call_replays_to_flattened_chat_name ... ok
test translate::tests::test_never_empties_the_message_array ... ok
test translate::tests::test_reasoning_effort_is_forwarded_verbatim ... ok
test translate::tests::test_null_user_message_is_dropped ... ok
test translate::tests::test_reasoning_without_effort_forwards_nothing ... ok
test translate::tests::test_skip_duplicate_function_call_from_history ... ok
test translate::tests::test_skip_duplicate_function_call_output_from_history ... ok
test translate::tests::test_system_from_input_replaces_instructions ... ok
test translate::tests::test_system_message_at_start_of_input ... ok
test translate::tests::test_system_prompt_from_instructions ... ok
test translate::tests::test_text_input_becomes_user_message ... ok
test translate::tests::test_system_message_between_tool_calls_moved_to_front ... ok
test translate::tests::test_text_only_parts_collapse_to_string ... ok
test translate::tests::test_to_chat_request_honors_tool_denylist_env ... ok
test translate::tests::test_value_to_text_parts_array ... ok
test translate::tests::test_value_to_text_string ... ok
test translate::tests::test_whitespace_only_user_message_is_dropped ... ok
test types::tests::cache_summary_handles_missing_usage_fields ... ok
test types::tests::cache_summary_uses_deepseek_top_level_cache_fields ... ok
test types::tests::cache_summary_prefers_top_level_hit_when_both_shapes_exist ... ok
test upstream_request::tests::merges_extra_params_and_drops_top_level_params ... ok
test types::tests::cache_summary_uses_openai_prompt_tokens_details ... ok
test upstream_request::tests::rejects_non_object_extra_params ... ok
test upstream_request::tests::rejects_non_string_drop_params ... ok
test session::tests::test_disk_store_save_load_history_across_instances ... ok
test session::tests::test_disk_store_turn_reasoning_across_instances ... ok
test dsml::tests::blocking_and_streaming_visible_text_match ... ok

test result: ok. 142 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 4 tests
test input_image_becomes_chat_completions_multimodal ... ok
test reasoning_input_items_are_dropped ... ok
test unknown_top_level_fields_dont_break_parse ... ok
test namespace_tools_are_flattened ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 10 tests
test live_deepseek_models_lists_both_keys ... ignored
test live_deepseek_v4_flash_blocking ... ignored
test live_deepseek_v4_flash_streaming ... ignored
test live_deepseek_v4_flash_tool_call ... ignored
test live_deepseek_v4_pro_blocking ... ignored
test live_deepseek_v4_pro_image_input_currently_rejected_by_upstream ... ignored
test live_deepseek_v4_pro_image_input_wire_shape ... ignored
test live_deepseek_v4_pro_reasoning_round_trip ... ignored
test live_deepseek_v4_pro_streaming ... ignored
test live_deepseek_v4_pro_tool_call ... ignored

test result: ok. 0 passed; 0 failed; 10 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test test_non_thinking_model_no_reasoning_content ... ok
test test_deepseek_v4_pro_reasoning_roundtrip_text_only ... ok
test test_deepseek_v4_pro_multi_turn_reasoning ... ok
test test_deepseek_v4_pro_reasoning_roundtrip_with_tool_calls ... ok
test test_kimi_k2_6_reasoning_via_call_id ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 2 tests
test live_kimi_k2_6_image_input_blocking ... ignored
test live_kimi_v1_vision_preview_image_input_blocking ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 29 tests
test blocking_response_usage_includes_cached_tokens ... ok
test dsml_leak_blocking_response_heals_into_function_call ... ok
test issue_20_blocking_hyphen_flat_tool_name_is_not_namespaced ... ok
test issue_17_blocking_namespaced_tool_calls_emit_namespace_field ... ok
test issue_26_glm_model_enables_thinking_on_upstream_request ... ok
test issue_26_non_glm_model_does_not_send_thinking ... ok
test issue_20_streaming_hyphen_flat_tool_name_is_not_namespaced ... ok
test dsml_heal_quirk_can_be_disabled_via_env ... ok
test issue_17_streaming_namespaced_tool_calls_emit_namespace_field ... ok
test issue_26_streaming_reasoning_alias_field_emits_reasoning_events ... ok
test blocking_think_tags_are_exposed_and_persisted_as_reasoning ... ok
test issue_37_custom_apply_patch_round_trips_in_blocking_translation ... ok
test issue_37_function_declared_apply_patch_emits_custom_tool_call ... ok
test issue_37_function_declared_apply_patch_respects_input_argument_field ... ok
test dsml_leak_streaming_heals_into_function_call_events ... ok
test issue_12_spawn_agent_child_context_should_not_replay_parent_history ... ok
test issue_24_v2_encrypted_spawn_child_context_is_isolated ... ok
test issue_6_namespace_tools_keep_namespace_when_flattened ... ok
test issue_31_unterminated_done_line_is_still_recognized ... ok
test issue_31_stream_without_done_still_completes_when_content_received ... ok
test issue_29_extra_and_drop_params_modify_streaming_upstream_request ... ok
test issue_26_streaming_reasoning_content_emits_responses_reasoning_events ... ok
test issue_43_streaming_collaboration_calls_request_plaintext_arguments ... ok
test issue_37_streaming_apply_patch_emits_custom_tool_events ... ok
test issue_31_truncated_stream_without_finish_reason_fails ... ok
test issue_5_streaming_completed_event_includes_usage ... ok
test streaming_response_usage_includes_cached_tokens ... ok
test think_tags_leaked_into_content_are_routed_to_reasoning ... ok
test issue_40_streaming_headers_and_keepalive_do_not_wait_for_upstream_headers ... ok

test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.61s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
- 
- 