### PR TITLE
fix: fail closed on incomplete upstream streams

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -915,44 +915,76 @@ async fn handle_blocking(
             )
                 .into_response()
         }
-        Ok(r) => match r.json::<ChatResponse>().await {
-            Err(e) => {
-                error!("parse error: {e}");
-                (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-            }
-            Ok(chat_resp) => {
-                debug!(
-                    "← upstream function_calls={}",
-                    summarize_debug_names(chat_response_tool_call_debug_names(&chat_resp))
-                );
-                let response_id = state.sessions.new_id();
-                let (resp, assistant_messages) =
-                    if namespace_tools.is_empty() && custom_tools.is_empty() {
-                        translate::from_chat_response(response_id.clone(), &model, chat_resp)
-                    } else {
-                        translate::from_chat_response_with_tool_maps(
-                            response_id.clone(),
-                            &model,
-                            chat_resp,
-                            &namespace_tools,
-                            &custom_tools,
-                        )
-                    };
-
-                let mut full_history = chat_req.messages;
-                full_history.extend(assistant_messages);
-                if let Some(corpus) = &state.corpus {
-                    corpus.record_turn(
-                        previous_response_id.as_deref(),
-                        &response_id,
-                        &model,
-                        &full_history,
-                    );
+        Ok(r) => {
+            let value = match r.json::<serde_json::Value>().await {
+                Ok(value) => value,
+                Err(e) => {
+                    error!("parse error: {e}");
+                    return (StatusCode::BAD_GATEWAY, e.to_string()).into_response();
                 }
-                state.sessions.save_with_id(response_id, full_history);
-                Json(resp).into_response()
+            };
+            if let Some(upstream_error) = value.get("error") {
+                let message = upstream_error
+                    .get("message")
+                    .and_then(serde_json::Value::as_str)
+                    .or_else(|| upstream_error.as_str())
+                    .unwrap_or("upstream returned an error")
+                    .to_string();
+                error!("upstream response error: {message}");
+                return (StatusCode::BAD_GATEWAY, message).into_response();
             }
-        },
+            match serde_json::from_value::<ChatResponse>(value) {
+                Err(e) => {
+                    error!("parse error: {e}");
+                    (StatusCode::BAD_GATEWAY, e.to_string()).into_response()
+                }
+                Ok(chat_resp) => {
+                    debug!(
+                        "← upstream function_calls={}",
+                        summarize_debug_names(chat_response_tool_call_debug_names(&chat_resp))
+                    );
+                    let response_id = state.sessions.new_id();
+                    let (resp, assistant_messages) =
+                        if namespace_tools.is_empty() && custom_tools.is_empty() {
+                            translate::from_chat_response(response_id.clone(), &model, chat_resp)
+                        } else {
+                            translate::from_chat_response_with_tool_maps(
+                                response_id.clone(),
+                                &model,
+                                chat_resp,
+                                &namespace_tools,
+                                &custom_tools,
+                            )
+                        };
+
+                    for assistant in &assistant_messages {
+                        if let Some(reasoning) = assistant
+                            .reasoning_content
+                            .as_ref()
+                            .filter(|reasoning| !reasoning.is_empty())
+                        {
+                            state.sessions.store_turn_reasoning(
+                                &chat_req.messages,
+                                assistant,
+                                reasoning.clone(),
+                            );
+                        }
+                    }
+                    let mut full_history = chat_req.messages;
+                    full_history.extend(assistant_messages);
+                    if let Some(corpus) = &state.corpus {
+                        corpus.record_turn(
+                            previous_response_id.as_deref(),
+                            &response_id,
+                            &model,
+                            &full_history,
+                        );
+                    }
+                    state.sessions.save_with_id(response_id, full_history);
+                    Json(resp).into_response()
+                }
+            }
+        }
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -173,18 +173,18 @@ impl SessionStore {
     /// of the assistant message content and tool calls.
     pub fn store_turn_reasoning(
         &self,
-        _prior: &[ChatMessage],
+        prior: &[ChatMessage],
         assistant: &ChatMessage,
         reasoning: String,
     ) {
         if !reasoning.is_empty() {
             let mut state = self.state.lock().expect("session store mutex poisoned");
 
-            // Store under content-only key so lookups work even when Codex
-            // replays the assistant text and function_calls as separate items.
+            // Store under a replay-visible turn key so identical assistant
+            // text in different conversations cannot overwrite reasoning.
             let content = assistant.text_content();
             if !content.is_empty() {
-                let key = Self::content_key(content);
+                let key = Self::turn_key(prior, assistant);
                 state.insert_turn_reasoning(key, reasoning.clone());
             }
             // Also store under each tool call_id (existing mechanism).
@@ -204,14 +204,14 @@ impl SessionStore {
     /// Look up reasoning_content for an assistant turn by its text content.
     pub fn get_turn_reasoning(
         &self,
-        _prior: &[ChatMessage],
+        prior: &[ChatMessage],
         assistant: &ChatMessage,
     ) -> Option<String> {
         let content = assistant.text_content();
         if content.is_empty() {
             return None;
         }
-        let key = Self::content_key(content);
+        let key = Self::turn_key(prior, assistant);
         let mut state = self.state.lock().expect("session store mutex poisoned");
         state.enforce_limits();
         let value = state.load_turn_reasoning_value(key);
@@ -221,10 +221,28 @@ impl SessionStore {
         value
     }
 
-    /// Hash assistant message content for turn-level reasoning lookup.
-    fn content_key(content: &str) -> u64 {
+    /// Hash replay-visible prior messages and assistant shape while excluding
+    /// reasoning_content itself, which is the value this key recovers.
+    fn turn_key(prior: &[ChatMessage], assistant: &ChatMessage) -> u64 {
         let mut hasher = DefaultHasher::new();
-        content.hash(&mut hasher);
+        for message in prior {
+            message.role.hash(&mut hasher);
+            serde_json::to_string(&(
+                &message.content,
+                &message.tool_calls,
+                &message.tool_call_id,
+                &message.name,
+            ))
+            .expect("chat message fields serialize")
+            .hash(&mut hasher);
+        }
+        // Codex replays assistant text and function calls as separate items,
+        // so the text-message key must not depend on tool_calls. Those are
+        // indexed independently by call_id above.
+        assistant.role.hash(&mut hasher);
+        serde_json::to_string(&(&assistant.content, &assistant.name))
+            .expect("assistant message fields serialize")
+            .hash(&mut hasher);
         hasher.finish()
     }
 
@@ -962,12 +980,33 @@ mod tests {
     }
 
     #[test]
-    fn test_content_key_deterministic() {
-        let a = SessionStore::content_key("same text");
-        let b = SessionStore::content_key("same text");
+    fn test_turn_key_is_deterministic_and_includes_prior() {
+        let assistant = msg("assistant", Some("same text"));
+        let prior = vec![msg("user", Some("question one"))];
+        let a = SessionStore::turn_key(&prior, &assistant);
+        let b = SessionStore::turn_key(&prior, &assistant);
         assert_eq!(a, b);
-        let c = SessionStore::content_key("different");
+        let c = SessionStore::turn_key(&[msg("user", Some("question two"))], &assistant);
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_turn_reasoning_does_not_cross_identical_assistant_text() {
+        let store = SessionStore::new();
+        let assistant = msg("assistant", Some("OK"));
+        let first_prior = vec![msg("user", Some("first"))];
+        let second_prior = vec![msg("user", Some("second"))];
+        store.store_turn_reasoning(&first_prior, &assistant, "first reasoning".into());
+        store.store_turn_reasoning(&second_prior, &assistant, "second reasoning".into());
+
+        assert_eq!(
+            store.get_turn_reasoning(&first_prior, &assistant),
+            Some("first reasoning".into())
+        );
+        assert_eq!(
+            store.get_turn_reasoning(&second_prior, &assistant),
+            Some("second reasoning".into())
+        );
     }
 
     #[test]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -150,7 +150,8 @@ pub fn translate_stream(
         let mut message_output_index: Option<usize> = None;
         let mut next_output_index: usize = 0;
         let mut stream_done = false;
-        let mut stream_err = false;
+        let mut stream_failure: Option<(&'static str, String)> = None;
+        let mut terminal_choice_seen = false;
         // The upstream's own end-of-turn signal. Distinguishes "provider closed
         // without [DONE]" (safe to complete) from "connection died mid-turn"
         // (must not be completed).
@@ -173,11 +174,11 @@ pub fn translate_stream(
             ))))
             .eventsource();
 
-        while let Some(ev) = source.next().await {
+        'events: while let Some(ev) = source.next().await {
             match ev {
                 Err(e) => {
                     warn!("SSE parse error: {e}");
-                    stream_err = true;
+                    stream_failure = Some(("stream_parse_error", e.to_string()));
                     break;
                 }
                 Ok(ev) if ev.data.trim() == "[DONE]" => {
@@ -186,23 +187,64 @@ pub fn translate_stream(
                 }
                 Ok(ev) if ev.data.is_empty() => continue,
                 Ok(ev) => {
-                    match serde_json::from_str::<ChatStreamChunk>(&ev.data) {
-                        Err(e) => warn!("chunk parse error: {e} — data: {}", ev.data),
+                    let value = match serde_json::from_str::<Value>(&ev.data) {
+                        Ok(value) => value,
+                        Err(e) => {
+                            let message = e.to_string();
+                            warn!("upstream SSE chunk rejected: {message}");
+                            stream_failure = Some(("invalid_stream_chunk", message));
+                            break 'events;
+                        }
+                    };
+                    if let Some(error) = value.get("error") {
+                        let message = error
+                            .get("message")
+                            .and_then(Value::as_str)
+                            .or_else(|| error.as_str())
+                            .unwrap_or("upstream stream error")
+                            .to_string();
+                        warn!("upstream SSE returned an error: {message}");
+                        stream_failure = Some(("upstream_stream_error", message));
+                        break 'events;
+                    }
+                    match serde_json::from_value::<ChatStreamChunk>(value) {
+                        Err(e) => {
+                            let message = e.to_string();
+                            warn!("upstream SSE chunk rejected: {message}");
+                            stream_failure = Some(("invalid_stream_chunk", message));
+                            break 'events;
+                        }
                         Ok(chunk) => {
                             let ChatStreamChunk { choices, usage } = chunk;
                             if usage.is_some() {
                                 stream_usage = usage;
                             }
+                            if !choices.is_empty()
+                                && (terminal_choice_seen
+                                    || choices.len() != 1
+                                    || choices[0].index != 0)
+                            {
+                                let message = if terminal_choice_seen {
+                                    "upstream sent choice data after finish_reason"
+                                } else {
+                                    "codex-relay supports only choice index 0"
+                                };
+                                stream_failure =
+                                    Some(("unsupported_stream_choices", message.to_string()));
+                                break 'events;
+                            }
                             for choice in &choices {
                                 if let Some(fr) = &choice.finish_reason {
                                     finish_reason = Some(fr.clone());
+                                    terminal_choice_seen = true;
                                 }
-                                // Split leaked `<think>` markup out of the text
-                                // content before anything else looks at it, so
-                                // thinking reaches the reasoning channel and
-                                // never enters accumulated_text or history.
-                                let think = think_filter
+                                // DSML parameters may legitimately contain
+                                // `<think>` text as part of a tool argument, so
+                                // isolate DSML before healing visible reasoning.
+                                // This matches the blocking translation order.
+                                let dsml_content = dsml_filter
                                     .push(choice.delta.content.as_deref().unwrap_or(""));
+                                let think = think_filter.push(&dsml_content);
                                 // Reasoning/thinking content (kimi-k2.6, GLM, etc.).
                                 // Field name varies by provider (reasoning_content
                                 // vs reasoning) — normalized via reasoning_text().
@@ -248,8 +290,8 @@ pub fn translate_stream(
                                     }
                                 }
 
-                                // Text content, filtered for leaked DSML markup.
-                                let content = dsml_filter.push(&think.text);
+                                // Visible text after DSML and think healing.
+                                let content = think.text;
                                 if !content.is_empty() {
                                     let output_index = match message_output_index {
                                         Some(idx) => idx,
@@ -316,10 +358,52 @@ pub fn translate_stream(
             }
         }
 
-        // Flush the think filter first: an unterminated `<think>` block stays
-        // on the reasoning channel rather than leaking into visible text.
+        // Decide the terminal state before flushing filters or marking any
+        // output item completed. Partial deltas may already have reached the
+        // client, but a truncated or malformed stream must never authorize a
+        // tool execution through `response.output_item.done`.
+        if !stream_done && stream_failure.is_none() && crate::quirks::quirk_enabled("missing_done") {
+            match finish_reason.as_deref() {
+                Some(reason) => {
+                    warn!("quirk missing_done fired: stream ended without [DONE] (finish_reason={reason}) — treating as complete");
+                    stream_done = true;
+                }
+                None if !accumulated_text.is_empty() || !tool_calls.is_empty() => {
+                    warn!("stream ended without [DONE] and without finish_reason — turn was truncated, discarding");
+                }
+                None => {}
+            }
+        }
+
+        if !stream_done {
+            let (code, message) = stream_failure.unwrap_or((
+                "stream_incomplete",
+                "stream disconnected before completion".to_string(),
+            ));
+            warn!("upstream stream failed before completion: {message}");
+            yield Ok(Event::default()
+                .event("response.failed")
+                .data(json!({
+                    "type": "response.failed",
+                    "response": {
+                        "id": &response_id,
+                        "status": "failed",
+                        "error": {"code": code, "message": message}
+                    }
+                }).to_string()));
+            return;
+        }
+
+        // Flush DSML before think healing, matching the per-delta and blocking
+        // order. Think-like text inside tool arguments remains untouched.
+        let (dsml_tail, dsml_calls) = dsml_filter.finish();
+        let mut think_tail = think_filter.push(&dsml_tail);
         let think_fired = think_filter.fired();
-        let think_tail = think_filter.finish();
+        let final_think_tail = think_filter.finish();
+        think_tail
+            .reasoning
+            .push_str(&final_think_tail.reasoning);
+        think_tail.text.push_str(&final_think_tail.text);
         if think_fired {
             warn!("quirk think_tags fired: split leaked <think> markup out of streamed text");
         }
@@ -355,14 +439,7 @@ pub fn translate_stream(
                     "delta": &think_tail.reasoning
                 }).to_string()));
         }
-        let think_leftover = dsml_filter.push(&think_tail.text);
-
-        // Flush the DSML filter: healed tool calls join the accumulated
-        // tool_calls (and are emitted as function_call/custom_tool_call items
-        // below); any remaining visible text is emitted as a final delta.
-        let (dsml_tail, dsml_calls) = dsml_filter.finish();
-        let dsml_leftover = format!("{think_leftover}{dsml_tail}");
-        if !dsml_leftover.is_empty() {
+        if !think_tail.text.is_empty() {
             let output_index = match message_output_index {
                 Some(idx) => idx,
                 None => {
@@ -385,14 +462,14 @@ pub fn translate_stream(
                     idx
                 }
             };
-            accumulated_text.push_str(&dsml_leftover);
+            accumulated_text.push_str(&think_tail.text);
             yield Ok(Event::default()
                 .event("response.output_text.delta")
                 .data(json!({
                     "type": "response.output_text.delta",
                     "item_id": &msg_item_id,
                     "output_index": output_index,
-                    "delta": &dsml_leftover
+                    "delta": &think_tail.text
                 }).to_string()));
         }
         if !dsml_calls.is_empty() {
@@ -552,25 +629,6 @@ pub fn translate_stream(
                 }).to_string()));
 
             fc_items.push((output_index, done_item));
-        }
-
-        // Some OpenAI-compatible providers close the SSE stream without a
-        // terminating `[DONE]` line. The upstream's own end-of-turn signal is
-        // `finish_reason`, not "we have some content": completing on content
-        // alone silently promotes a connection that died mid-generation into a
-        // successful turn, which then gets persisted to history. A mid-stream
-        // error (stream_err) still discards the partial turn.
-        if !stream_done && !stream_err && crate::quirks::quirk_enabled("missing_done") {
-            match finish_reason.as_deref() {
-                Some(reason) => {
-                    warn!("quirk missing_done fired: stream ended without [DONE] (finish_reason={reason}) — treating as complete");
-                    stream_done = true;
-                }
-                None if !accumulated_text.is_empty() || !tool_calls.is_empty() => {
-                    warn!("stream ended without [DONE] and without finish_reason — turn was truncated, discarding");
-                }
-                None => {}
-            }
         }
 
         if stream_done {

--- a/src/think.rs
+++ b/src/think.rs
@@ -47,8 +47,6 @@ pub struct ThinkSplit {
 pub struct ThinkStreamFilter {
     pending: String,
     in_think: bool,
-    emitted_text: bool,
-    trim_after_close: bool,
     fired: bool,
     enabled: bool,
 }
@@ -66,8 +64,6 @@ impl ThinkStreamFilter {
         Self {
             pending: String::new(),
             in_think: false,
-            emitted_text: false,
-            trim_after_close: false,
             fired: false,
             enabled,
         }
@@ -92,7 +88,6 @@ impl ThinkStreamFilter {
                     out.reasoning.push_str(&self.pending[..at]);
                     self.pending.drain(..at + tag.len());
                     self.in_think = false;
-                    self.trim_after_close = !self.emitted_text;
                     continue;
                 }
                 let keep =
@@ -100,23 +95,6 @@ impl ThinkStreamFilter {
                 out.reasoning.push_str(&self.pending[..keep]);
                 self.pending.drain(..keep);
                 return out;
-            }
-
-            if self.trim_after_close {
-                let first_non_whitespace = self
-                    .pending
-                    .char_indices()
-                    .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index));
-                match first_non_whitespace {
-                    Some(index) => {
-                        self.pending.drain(..index);
-                        self.trim_after_close = false;
-                    }
-                    None => {
-                        self.pending.clear();
-                        return out;
-                    }
-                }
             }
 
             match first_tag(&self.pending, OPEN_TAGS) {
@@ -145,11 +123,7 @@ impl ThinkStreamFilter {
         if self.in_think {
             out.reasoning = rest;
         } else {
-            out.text = if self.trim_after_close && !self.emitted_text {
-                rest.trim_start().to_string()
-            } else {
-                rest
-            };
+            out.text = rest;
         }
         out
     }
@@ -158,7 +132,6 @@ impl ThinkStreamFilter {
     fn emit_text(&mut self, out: &mut ThinkSplit, upto: usize) {
         let chunk = &self.pending[..upto];
         if !chunk.is_empty() {
-            self.emitted_text = true;
             out.text.push_str(chunk);
         }
     }
@@ -171,26 +144,15 @@ pub fn heal_chat_message(message: &mut ChatMessage) {
     if !contains_think_markup(&text) {
         return;
     }
-    let (split, fired) = if first_tag(&text, OPEN_TAGS).is_none() {
-        match first_tag(&text, CLOSE_TAGS) {
-            Some((at, tag)) => (
-                ThinkSplit {
-                    reasoning: text[..at].to_string(),
-                    text: text[at + tag.len()..].trim_start().to_string(),
-                },
-                true,
-            ),
-            None => (ThinkSplit::default(), false),
-        }
-    } else {
-        let mut filter = ThinkStreamFilter::new(true);
-        let mut split = filter.push(&text);
-        let fired = filter.fired();
-        let tail = filter.finish();
-        split.reasoning.push_str(&tail.reasoning);
-        split.text.push_str(&tail.text);
-        (split, fired)
-    };
+    if first_tag(&text, OPEN_TAGS).is_none() {
+        return;
+    }
+    let mut filter = ThinkStreamFilter::new(true);
+    let mut split = filter.push(&text);
+    let fired = filter.fired();
+    let tail = filter.finish();
+    split.reasoning.push_str(&tail.reasoning);
+    split.text.push_str(&tail.text);
     if !fired {
         return;
     }
@@ -261,7 +223,7 @@ mod tests {
     fn splits_a_complete_think_block() {
         let out = run(&["<think>musing</think>\n\nHello!"]);
         assert_eq!(out.reasoning, "musing");
-        assert_eq!(out.text, "Hello!");
+        assert_eq!(out.text, "\n\nHello!");
     }
 
     #[test]
@@ -298,6 +260,12 @@ mod tests {
         let expected = run(&["<think>musing</think>Hi"]);
         assert_eq!(expected, run(&["<thi", "nk>musing</th", "ink>Hi"]));
         assert_eq!(expected, run(&["<think>musing</think>", "Hi"]));
+    }
+
+    #[test]
+    fn preserves_whitespace_after_think_block() {
+        assert_eq!(run(&["<think>x</think>  indented"]).text, "  indented");
+        assert_eq!(run(&["<think>x</think>\n    code"]).text, "\n    code");
     }
 
     #[test]
@@ -356,7 +324,7 @@ mod tests {
     }
 
     #[test]
-    fn heals_blocking_message_with_prefilled_open_tag() {
+    fn blocking_bare_close_tag_stays_visible_like_streaming() {
         let mut message = ChatMessage {
             role: "assistant".into(),
             content: Some("musing</think>Hi".into()),
@@ -366,8 +334,8 @@ mod tests {
             name: None,
         };
         heal_chat_message(&mut message);
-        assert_eq!(message.text_content(), "Hi");
-        assert_eq!(message.reasoning_content.as_deref(), Some("musing"));
+        assert_eq!(message.text_content(), "musing</think>Hi");
+        assert!(message.reasoning_content.is_none());
     }
 
     #[test]

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -1263,6 +1263,7 @@ mod tests {
 
     #[test]
     fn test_from_chat_response_uses_request_tool_map_for_namespace() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let chat = ChatResponse {
             choices: vec![ChatChoice {
                 message: ChatMessage {
@@ -1301,6 +1302,7 @@ mod tests {
 
     #[test]
     fn test_collaboration_calls_request_plaintext_arguments() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let call_names = [
             "collaboration-spawn_agent",
             "collaboration-send_message",

--- a/src/types.rs
+++ b/src/types.rs
@@ -232,6 +232,8 @@ pub struct ChatStreamChunk {
 
 #[derive(Debug, Deserialize)]
 pub struct ChatStreamChoice {
+    #[serde(default)]
+    pub index: usize,
     pub delta: ChatDelta,
     /// Upstream end-of-turn signal. Used by stream.rs to tell a provider that
     /// merely omitted `[DONE]` from a connection that died mid-generation.

--- a/src/upstream_request.rs
+++ b/src/upstream_request.rs
@@ -41,6 +41,12 @@ impl UpstreamRequestConfig {
         for (key, value) in &self.extra_params {
             object.insert(key.clone(), value.clone());
         }
+        if object
+            .get("n")
+            .is_some_and(|value| value.as_u64() != Some(1))
+        {
+            bail!("codex-relay supports only one upstream completion (n=1)");
+        }
 
         Ok(body)
     }
@@ -119,6 +125,13 @@ mod tests {
     #[test]
     fn rejects_non_object_extra_params() {
         assert!(UpstreamRequestConfig::from_raw(Some(r#"["thinking"]"#), None).is_err());
+    }
+
+    #[test]
+    fn rejects_multiple_upstream_completions() {
+        let config = UpstreamRequestConfig::from_raw(Some(r#"{"n":2}"#), None).unwrap();
+        let error = config.request_body(&chat_request()).unwrap_err();
+        assert!(error.to_string().contains("n=1"));
     }
 
     #[test]

--- a/tests/compat_deepseek_v4_pro.rs
+++ b/tests/compat_deepseek_v4_pro.rs
@@ -37,6 +37,17 @@ fn assistant_msg(content: &str) -> ChatMessage {
     }
 }
 
+fn user_msg(content: &str) -> ChatMessage {
+    ChatMessage {
+        role: "user".into(),
+        content: Some(content.into()),
+        reasoning_content: None,
+        tool_calls: None,
+        tool_call_id: None,
+        name: None,
+    }
+}
+
 fn assistant_msg_with_tool_calls(content: &str, tool_calls: Vec<serde_json::Value>) -> ChatMessage {
     ChatMessage {
         role: "assistant".into(),
@@ -57,7 +68,7 @@ fn test_deepseek_v4_pro_reasoning_roundtrip_text_only() {
     // Simulate turn 1: model returned text + reasoning
     let assistant = assistant_msg("Let me analyze this");
     store.store_turn_reasoning(
-        &[],
+        &[user_msg("Research task prompt")],
         &assistant,
         "<think>analyzing the problem...</think>".into(),
     );
@@ -101,7 +112,11 @@ fn test_deepseek_v4_pro_reasoning_roundtrip_with_tool_calls() {
             "function": {"name": "exec_command", "arguments": "{\"cmd\": \"ls\"}"}
         })],
     );
-    store.store_turn_reasoning(&[], &assistant, "<think>need to read files</think>".into());
+    store.store_turn_reasoning(
+        &[user_msg("Prompt")],
+        &assistant,
+        "<think>need to read files</think>".into(),
+    );
 
     // Turn 2: Codex replays conversation with separate items
     let req = base_req(ResponsesInput::Messages(vec![
@@ -149,7 +164,7 @@ fn test_deepseek_v4_pro_multi_turn_reasoning() {
     // Store reasoning for turn 1
     let assistant1 = assistant_msg("Step 1 analysis");
     store.store_turn_reasoning(
-        &[],
+        &[user_msg("Start research")],
         &assistant1,
         "<think>first pass thinking</think>".into(),
     );
@@ -157,7 +172,11 @@ fn test_deepseek_v4_pro_multi_turn_reasoning() {
     // Store reasoning for turn 2
     let assistant2 = assistant_msg("Step 2 deeper look");
     store.store_turn_reasoning(
-        &[],
+        &[
+            user_msg("Start research"),
+            assistant1.clone(),
+            user_msg("Go deeper"),
+        ],
         &assistant2,
         "<think>second pass thinking</think>".into(),
     );

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -388,7 +388,7 @@ async fn dsml_leak_streaming_heals_into_function_call_events() {
         json!({"choices": [{"delta": {"content": "我来读取文件。"}}]}),
         json!({"choices": [{"delta": {"content": "<｜DS"}}]}),
         json!({"choices": [{"delta": {"content": "ML｜tool_calls>\n<｜DSML｜invoke name=\"shell\">\n"}}]}),
-        json!({"choices": [{"delta": {"content": "<｜DSML｜parameter name=\"command\" string=\"true\">ls -la</｜DSML｜parameter>\n</｜DSML｜invoke>\n"}}]}),
+        json!({"choices": [{"delta": {"content": "<｜DSML｜parameter name=\"command\" string=\"true\">echo <think>secret</think></｜DSML｜parameter>\n</｜DSML｜invoke>\n"}}]}),
         json!({"choices": [{"delta": {"content": "</｜DSML｜tool_calls>"}}]}),
         json!({"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}),
     ]);
@@ -423,7 +423,13 @@ async fn dsml_leak_streaming_heals_into_function_call_events() {
         .expect("healed function_call done item");
     assert_eq!(fc_done["name"], "shell");
     let args: Value = serde_json::from_str(fc_done["arguments"].as_str().unwrap()).unwrap();
-    assert_eq!(args["command"], "ls -la");
+    assert_eq!(args["command"], "echo <think>secret</think>");
+    assert!(
+        events
+            .iter()
+            .all(|(event, _)| event != "response.reasoning_summary_text.delta"),
+        "think-like text inside DSML arguments is tool data, not reasoning"
+    );
     assert!(fc_done["call_id"]
         .as_str()
         .unwrap()
@@ -1123,6 +1129,127 @@ async fn issue_31_truncated_stream_without_finish_reason_fails() {
         events.iter().any(|(event, _)| event == "response.failed"),
         "truncated turn must not be reported as completed"
     );
+    assert!(
+        events
+            .iter()
+            .all(|(event, _)| event != "response.output_item.done"),
+        "failed stream must not finalize partial output items"
+    );
+}
+
+#[tokio::test]
+async fn issue_46_truncated_tool_call_is_never_finalized() {
+    let truncated = sse_from_chunks_without_done(vec![json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "id": "call_danger",
+                    "function": {"name": "dangerous_tool", "arguments": "{\"path\":\"/tmp/x\"}"}
+                }]
+            }
+        }]
+    })]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![truncated]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({"model": "mock-model", "input": "act", "tools": [], "stream": true}),
+    )
+    .await;
+
+    assert!(events.iter().any(|(event, _)| event == "response.failed"));
+    assert!(events
+        .iter()
+        .all(|(event, _)| event != "response.output_item.done"));
+    assert!(events
+        .iter()
+        .all(|(event, _)| event != "response.completed"));
+}
+
+#[tokio::test]
+async fn issue_46_embedded_upstream_error_fails_even_with_done() {
+    let sse = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n",
+        "data: {\"choices\":[],\"error\":{\"message\":\"upstream quota exceeded\"}}\n\n",
+        "data: [DONE]\n\n"
+    )
+    .to_string();
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({"model": "mock-model", "input": "Say hi.", "tools": [], "stream": true}),
+    )
+    .await;
+
+    let failed = events
+        .iter()
+        .find_map(|(event, data)| (event == "response.failed").then_some(data))
+        .expect("response.failed");
+    assert_eq!(
+        failed["response"]["error"]["message"],
+        "upstream quota exceeded"
+    );
+    assert!(events
+        .iter()
+        .all(|(event, _)| event != "response.output_item.done"));
+    assert!(events
+        .iter()
+        .all(|(event, _)| event != "response.completed"));
+}
+
+#[tokio::test]
+async fn issue_46_choice_after_finish_reason_fails() {
+    let sse = sse_from_chunks_without_done(vec![
+        json!({"choices":[{"index":0,"delta":{"content":"done"},"finish_reason":"stop"}]}),
+        json!({"choices":[{"index":0,"delta":{"tool_calls":[{
+            "index":0,"id":"late_call","function":{"name":"dangerous_tool","arguments":"{}"}
+        }]}}]}),
+    ]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({"model": "mock-model", "input": "act", "tools": [], "stream": true}),
+    )
+    .await;
+
+    assert!(events.iter().any(|(event, _)| event == "response.failed"));
+    assert!(events
+        .iter()
+        .all(|(event, _)| event != "response.output_item.done"));
+    assert!(events
+        .iter()
+        .all(|(event, _)| event != "response.completed"));
+}
+
+#[tokio::test]
+async fn issue_46_blocking_embedded_error_is_not_persisted_as_success() {
+    let (upstream_port, _bodies) = spawn_blocking_mock_upstream(vec![json!({
+        "choices": [],
+        "error": {"message": "quota exceeded"}
+    })])
+    .await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let response = reqwest::Client::new()
+        .post(relay.url("/v1/responses"))
+        .json(&json!({
+            "model": "mock-model",
+            "input": "Say hi.",
+            "tools": [],
+            "stream": false
+        }))
+        .send()
+        .await
+        .expect("relay response");
+
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_GATEWAY);
+    assert!(response.text().await.unwrap().contains("quota exceeded"));
 }
 
 #[tokio::test]
@@ -1155,7 +1282,10 @@ async fn think_tags_leaked_into_content_are_routed_to_reasoning() {
         .filter_map(|(_, data)| data["delta"].as_str())
         .collect();
 
-    assert_eq!(text, "Hello!", "think markup must not reach visible text");
+    assert_eq!(
+        text, "\n\nHello!",
+        "think markup must not reach visible text or consume surrounding whitespace"
+    );
     assert_eq!(reasoning, "musing");
 }
 


### PR DESCRIPTION
## Summary

Oracle follow-up for #46:

- never finalize output items from failed or truncated streams
- reject malformed chunks and HTTP 200 embedded errors before persistence
- allow only choice index 0 / n=1 and reject deltas after finish_reason
- run DSML healing before think healing in both blocking and streaming paths
- preserve whitespace around explicit think tags and keep bare close tags visible
- index blocking reasoning by replay-visible conversation context

## Verification

- cargo test
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check