### PR TITLE
fix: redact malformed request logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -580,10 +580,12 @@ async fn handle_responses(State(state): State<AppState>, body: axum::body::Bytes
     let req: ResponsesRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,
         Err(e) => {
-            error!("JSON parse error: {e}");
             error!(
-                "body prefix: {}",
-                String::from_utf8_lossy(&body[..body.len().min(200)])
+                error_category = ?e.classify(),
+                line = e.line(),
+                column = e.column(),
+                body_bytes = body.len(),
+                "JSON parse error"
             );
             return (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response();
         }


### PR DESCRIPTION
Follow-up to #48 after Oracle review.

Malformed Responses requests can include prompts, instructions, or tool arguments. Avoid logging either the raw body prefix or serde error text, which may echo an invalid field value. Log only non-sensitive parse metadata: error category, line, column, and body length. The 422 response remains unchanged.

Validation:
- cargo test
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check