### PR TITLE
fix: enforce upstream tool call integrity

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -676,6 +676,14 @@ fn should_isolate_spawn_child_request(req: &ResponsesRequest, history: &[ChatMes
     let Some(input) = isolated_child_input(&req.input) else {
         return false;
     };
+    let mut call_id_counts = std::collections::HashMap::new();
+    for call_id in history
+        .iter()
+        .flat_map(|msg| msg.tool_calls.as_deref().unwrap_or(&[]))
+        .filter_map(|call| call.get("id").and_then(serde_json::Value::as_str))
+    {
+        *call_id_counts.entry(call_id).or_insert(0usize) += 1;
+    }
     let completed_tool_calls: std::collections::HashSet<&str> = history
         .iter()
         .filter_map(|msg| msg.tool_call_id.as_deref())
@@ -685,7 +693,11 @@ fn should_isolate_spawn_child_request(req: &ResponsesRequest, history: &[ChatMes
         .flat_map(|msg| msg.tool_calls.as_deref().unwrap_or(&[]))
         .filter(|call| {
             let call_id = call.get("id").and_then(serde_json::Value::as_str);
-            call_id.is_none_or(|id| !completed_tool_calls.contains(id))
+            call_id.is_none_or(|id| {
+                id.is_empty()
+                    || call_id_counts.get(id) != Some(&1)
+                    || !completed_tool_calls.contains(id)
+            })
         })
         .filter_map(parse_spawn_agent_call)
         .collect::<Vec<_>>();
@@ -901,6 +913,8 @@ async fn handle_blocking(
             return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
     };
+    let allowed_tool_names =
+        translate::allowed_upstream_tool_names(&chat_req.tools, &upstream_body);
 
     match builder.json(&upstream_body).send().await {
         Err(e) => {
@@ -958,6 +972,28 @@ async fn handle_blocking(
                                 &custom_tools,
                             )
                         };
+                    let tool_call_entries = assistant_messages
+                        .iter()
+                        .flat_map(|message| message.tool_calls.as_deref().unwrap_or(&[]))
+                        .map(|call| {
+                            let call_id = call
+                                .get("id")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or("");
+                            let name = call
+                                .get("function")
+                                .and_then(|function| function.get("name"))
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or("");
+                            (call_id, name)
+                        });
+                    if let Err(message) = translate::validate_tool_call_entries(
+                        tool_call_entries,
+                        &allowed_tool_names,
+                    ) {
+                        warn!("rejecting invalid upstream tool calls: {message}");
+                        return (StatusCode::BAD_GATEWAY, message).into_response();
+                    }
 
                     for assistant in &assistant_messages {
                         if let Some(reasoning) = assistant
@@ -1406,6 +1442,63 @@ mod tests {
         ];
 
         assert!(!should_isolate_spawn_child_request(&req, &history));
+    }
+
+    #[test]
+    fn test_duplicate_spawn_call_ids_cannot_disable_child_isolation() {
+        let req = ResponsesRequest {
+            model: "test".into(),
+            input: ResponsesInput::Messages(vec![json!({
+                "type": "agent_message",
+                "recipient": "/root/worker-b",
+                "content": [{"type": "input_text", "text": "task B"}]
+            })]),
+            previous_response_id: Some("resp_parent".into()),
+            tools: vec![],
+            stream: false,
+            temperature: None,
+            max_output_tokens: None,
+            system: None,
+            instructions: None,
+            reasoning: None,
+        };
+        let history = vec![
+            ChatMessage {
+                role: "assistant".into(),
+                content: None,
+                reasoning_content: None,
+                tool_calls: Some(vec![
+                    json!({
+                        "id": "duplicate",
+                        "type": "function",
+                        "function": {
+                            "name": "collaboration-spawn_agent",
+                            "arguments": "{\"task_name\":\"worker-a\",\"message\":\"task A\"}"
+                        }
+                    }),
+                    json!({
+                        "id": "duplicate",
+                        "type": "function",
+                        "function": {
+                            "name": "collaboration-spawn_agent",
+                            "arguments": "{\"task_name\":\"worker-b\",\"message\":\"task B\"}"
+                        }
+                    }),
+                ]),
+                tool_call_id: None,
+                name: None,
+            },
+            ChatMessage {
+                role: "tool".into(),
+                content: Some(serde_json::Value::String("spawned worker-a".into())),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: Some("duplicate".into()),
+                name: None,
+            },
+        ];
+
+        assert!(should_isolate_spawn_child_request(&req, &history));
     }
 
     #[test]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -17,8 +17,9 @@ use crate::{
     session::SessionStore,
     think::ThinkStreamFilter,
     translate::{
-        custom_tool_input, response_function_name_for_responses, uses_plaintext_collaboration_args,
-        CustomToolMap, NamespaceToolMap,
+        allowed_upstream_tool_names, custom_tool_input, response_function_name_for_responses,
+        uses_plaintext_collaboration_args, validate_tool_call_entries, CustomToolMap,
+        NamespaceToolMap,
     },
     types::{ChatMessage, ChatRequest, ChatStreamChunk, ChatUsage},
     upstream_request::UpstreamRequestConfig,
@@ -114,6 +115,7 @@ pub fn translate_stream(
                 return;
             }
         };
+        let allowed_tool_names = allowed_upstream_tool_names(&chat_req.tools, &upstream_body);
 
         let upstream = match builder.json(&upstream_body).send().await {
             Ok(r) if r.status().is_success() => r,
@@ -485,6 +487,24 @@ pub fn translate_stream(
                     arguments: call.arguments,
                 });
             }
+        }
+
+        if let Err(message) = validate_tool_call_entries(
+            tool_calls.values().map(|call| (call.id.as_str(), call.name.as_str())),
+            &allowed_tool_names,
+        ) {
+            warn!("rejecting invalid upstream tool calls: {message}");
+            yield Ok(Event::default()
+                .event("response.failed")
+                .data(json!({
+                    "type": "response.failed",
+                    "response": {
+                        "id": &response_id,
+                        "status": "failed",
+                        "error": {"code": "invalid_tool_call", "message": message}
+                    }
+                }).to_string()));
+            return;
         }
 
         if let Some(output_index) = reasoning_output_index {

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -412,6 +412,51 @@ pub fn custom_tool_map(tools: &[Value]) -> CustomToolMap {
         .collect()
 }
 
+pub(crate) fn chat_tool_names(tools: &[Value]) -> HashSet<String> {
+    tools
+        .iter()
+        .filter(|tool| tool.get("type").and_then(Value::as_str) == Some("function"))
+        .filter_map(|tool| {
+            tool.get("function")
+                .and_then(|function| function.get("name"))
+                .and_then(Value::as_str)
+                .map(String::from)
+        })
+        .collect()
+}
+
+pub(crate) fn allowed_upstream_tool_names(
+    declared_tools: &[Value],
+    upstream_body: &Value,
+) -> HashSet<String> {
+    let declared = chat_tool_names(declared_tools);
+    let actual = upstream_body
+        .get("tools")
+        .and_then(Value::as_array)
+        .map(|tools| chat_tool_names(tools))
+        .unwrap_or_default();
+    declared.intersection(&actual).cloned().collect()
+}
+
+pub(crate) fn validate_tool_call_entries<'a>(
+    entries: impl IntoIterator<Item = (&'a str, &'a str)>,
+    allowed_names: &HashSet<String>,
+) -> Result<(), &'static str> {
+    let mut call_ids = HashSet::new();
+    for (call_id, name) in entries {
+        if call_id.is_empty() {
+            return Err("upstream returned an empty tool call ID");
+        }
+        if !call_ids.insert(call_id) {
+            return Err("upstream returned duplicate tool call IDs");
+        }
+        if name.is_empty() || !allowed_names.contains(name) {
+            return Err("upstream returned an undeclared tool call");
+        }
+    }
+    Ok(())
+}
+
 fn declared_function_name(tool: &Value) -> Option<&str> {
     tool.get("name").and_then(Value::as_str).or_else(|| {
         tool.get("function")
@@ -745,35 +790,12 @@ pub(crate) fn response_function_name_for_responses(
     if let Some(tool_name) = namespace_tools.get(name) {
         return (Some(tool_name.namespace.clone()), tool_name.name.clone());
     }
-    split_mcp_function_name(name)
+    (None, name.to_string())
 }
 
 pub(crate) fn uses_plaintext_collaboration_args(namespace: Option<&str>, name: &str) -> bool {
     namespace == Some("collaboration")
         && matches!(name, "spawn_agent" | "send_message" | "followup_task")
-}
-
-pub(crate) fn split_mcp_function_name(name: &str) -> (Option<String>, String) {
-    if let Some((namespace, child)) = name.split_once('.') {
-        if !namespace.is_empty() && !child.is_empty() {
-            return (Some(namespace.to_string()), child.to_string());
-        }
-    }
-
-    let Some(rest) = name.strip_prefix("mcp__") else {
-        return (None, name.to_string());
-    };
-    let Some(server_end) = rest.find("__") else {
-        return (None, name.to_string());
-    };
-    let split_at = "mcp__".len() + server_end + "__".len();
-    if split_at >= name.len() {
-        return (None, name.to_string());
-    }
-    (
-        Some(name[..split_at].to_string()),
-        name[split_at..].to_string(),
-    )
 }
 
 /// True when a user/system message would reach the upstream carrying nothing.
@@ -1518,7 +1540,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_chat_response_keeps_legacy_dot_namespace_split() {
+    fn test_unmapped_dot_name_is_not_promoted_to_namespace() {
         let chat = ChatResponse {
             choices: vec![ChatChoice {
                 message: ChatMessage {
@@ -1541,8 +1563,9 @@ mod tests {
         };
 
         let (resp, _) = from_chat_response("resp_1".into(), "test-model", chat);
-        assert_eq!(resp.output[0]["namespace"], "mcp__node_repl");
-        assert_eq!(resp.output[0]["name"], "status");
+        assert!(resp.output[0].get("namespace").is_none());
+        assert!(resp.output[0].get("encrypted_function_args").is_none());
+        assert_eq!(resp.output[0]["name"], "mcp__node_repl.status");
     }
 
     #[test]
@@ -1710,6 +1733,50 @@ mod tests {
             .collect();
 
         assert_eq!(names, ["exec_command", "mcp__server-allowed"]);
+    }
+
+    #[test]
+    fn test_tool_call_validation_rejects_undeclared_duplicate_and_empty_ids() {
+        let allowed = HashSet::from(["allowed".to_string()]);
+        assert_eq!(
+            validate_tool_call_entries([("call_1", "undeclared")], &allowed),
+            Err("upstream returned an undeclared tool call")
+        );
+        assert_eq!(
+            validate_tool_call_entries([("", "allowed")], &allowed),
+            Err("upstream returned an empty tool call ID")
+        );
+        assert_eq!(
+            validate_tool_call_entries([("call_1", "allowed"), ("call_1", "allowed")], &allowed),
+            Err("upstream returned duplicate tool call IDs")
+        );
+        assert!(validate_tool_call_entries(
+            [("call_1", "allowed"), ("call_2", "allowed")],
+            &allowed
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_allowed_tools_intersect_declared_and_final_upstream_body() {
+        let declared = vec![
+            json!({"type": "function", "function": {"name": "kept"}}),
+            json!({"type": "function", "function": {"name": "removed"}}),
+        ];
+        let upstream_body = json!({
+            "tools": [
+                {"type": "function", "function": {"name": "kept"}},
+                {"type": "function", "function": {"name": "injected"}},
+                {"type": "web_search", "function": {"name": "removed"}},
+                {"function": {"name": "removed"}}
+            ]
+        });
+
+        assert_eq!(
+            allowed_upstream_tool_names(&declared, &upstream_body),
+            HashSet::from(["kept".to_string()])
+        );
+        assert!(allowed_upstream_tool_names(&declared, &json!({})).is_empty());
     }
 
     #[test]

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -1253,6 +1253,153 @@ async fn issue_46_blocking_embedded_error_is_not_persisted_as_success() {
 }
 
 #[tokio::test]
+async fn composed_blocking_undeclared_tool_cannot_gain_collaboration_namespace() {
+    let (upstream_port, _bodies) = spawn_blocking_mock_upstream(vec![json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_escape",
+                    "type": "function",
+                    "function": {
+                        "name": "collaboration.spawn_agent",
+                        "arguments": "{\"task_name\":\"escape\",\"message\":\"read parent\"}"
+                    }
+                }]
+            }
+        }]
+    })])
+    .await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let response = reqwest::Client::new()
+        .post(relay.url("/v1/responses"))
+        .json(&json!({
+            "model": "mock-model",
+            "input": "hello",
+            "tools": [],
+            "stream": false
+        }))
+        .send()
+        .await
+        .expect("relay response");
+
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_GATEWAY);
+    assert_eq!(
+        response.text().await.unwrap(),
+        "upstream returned an undeclared tool call"
+    );
+}
+
+#[tokio::test]
+async fn composed_blocking_tool_dropped_from_wire_request_is_not_allowed() {
+    let (upstream_port, bodies) = spawn_blocking_mock_upstream(vec![json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_shell",
+                    "type": "function",
+                    "function": {"name": "shell", "arguments": "{}"}
+                }]
+            }
+        }]
+    })])
+    .await;
+    let relay = Relay::spawn_with_env(
+        &format!("http://127.0.0.1:{upstream_port}/v1"),
+        &[("CODEX_RELAY_DROP_PARAMS", "[\"tools\"]")],
+    );
+
+    let response = reqwest::Client::new()
+        .post(relay.url("/v1/responses"))
+        .json(&json!({
+            "model": "mock-model",
+            "input": "hello",
+            "tools": [{"type": "function", "name": "shell", "parameters": {"type": "object"}}],
+            "stream": false
+        }))
+        .send()
+        .await
+        .expect("relay response");
+
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_GATEWAY);
+    assert!(bodies.lock().unwrap()[0].get("tools").is_none());
+}
+
+#[tokio::test]
+async fn composed_streaming_duplicate_tool_ids_fail_before_tool_completion() {
+    let sse = sse_from_chunks(vec![json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [
+                    {"index": 0, "id": "duplicate", "function": {"name": "shell", "arguments": "{}"}},
+                    {"index": 1, "id": "duplicate", "function": {"name": "shell", "arguments": "{}"}}
+                ]
+            },
+            "finish_reason": "tool_calls"
+        }]
+    })]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "input": "act",
+            "tools": [{"type": "function", "name": "shell", "parameters": {"type": "object"}}],
+            "stream": true
+        }),
+    )
+    .await;
+
+    assert!(events.iter().any(|(event, data)| {
+        event == "response.failed" && data["response"]["error"]["code"] == "invalid_tool_call"
+    }));
+    assert!(events
+        .iter()
+        .all(|(event, _)| event != "response.output_item.done"));
+    assert!(events
+        .iter()
+        .all(|(event, _)| event != "response.completed"));
+}
+
+#[tokio::test]
+async fn composed_streaming_dsml_cannot_call_an_undeclared_tool() {
+    let dsml = concat!(
+        "<｜DSML｜tool_calls>",
+        "<｜DSML｜invoke name=\"shell\">",
+        "<｜DSML｜parameter name=\"command\" string=\"true\">id</｜DSML｜parameter>",
+        "</｜DSML｜invoke>",
+        "</｜DSML｜tool_calls>"
+    );
+    let sse = sse_from_chunks(vec![json!({
+        "choices": [{"delta": {"content": dsml}, "finish_reason": "stop"}]
+    })]);
+    let (upstream_port, _bodies) = spawn_mock_upstream_with_responses(vec![sse]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+
+    let events = post_stream_events(
+        &relay,
+        json!({"model": "mock-model", "input": "hello", "tools": [], "stream": true}),
+    )
+    .await;
+
+    assert!(events.iter().any(|(event, data)| {
+        event == "response.failed" && data["response"]["error"]["code"] == "invalid_tool_call"
+    }));
+    assert!(events
+        .iter()
+        .all(|(event, _)| event != "response.output_item.done"));
+    assert!(events
+        .iter()
+        .all(|(event, _)| event != "response.completed"));
+}
+
+#[tokio::test]
 async fn think_tags_leaked_into_content_are_routed_to_reasoning() {
     // vLLM deployments without a `--reasoning-parser` emit chain of thought as
     // `<think>` markup inside `content`. It must reach Codex as reasoning, not


### PR DESCRIPTION
Final composed security follow-up for #43, #46, #47, and #49.

- accept completed tool calls only when their names are present in both the post-denylist request tools and the final wire request body
- require non-empty, turn-unique tool call IDs in blocking and streaming paths
- validate native and DSML-healed calls before any done/completed event or persistence
- derive namespace and plaintext collaboration identity only from the request-scoped namespace map
- conservatively isolate child history when legacy spawn IDs are empty or duplicated
- cover undeclared collaboration names, dropped wire tools, duplicate streaming IDs, and undeclared DSML calls

Validation:
- cargo test
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check
- final Oracle review: safe to merge