### PR TITLE
Fix zero-argument tool replay and Codex model catalog config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,38 +39,36 @@ On startup, the relay logs the available upstream models and prints a hint:
 ```bash
 codex-relay --print-config \
   --upstream https://api.deepseek.com/v1 \
-  --api-key $DEEPSEEK_API_KEY
+  --api-key $DEEPSEEK_API_KEY \
+  --model-catalog ~/.codex/codex-relay-models.json
 ```
 
-This prints a ready-to-use `~/.codex/config.toml` snippet that includes
-`model_properties` for every upstream model, so Codex knows model capabilities
-and you won't see the **"Model metadata … not found"** warning.
+This prints a ready-to-use `~/.codex/config.toml` snippet and writes a model
+catalog containing both Codex's built-in models and every upstream model, so
+you won't see the **"Model metadata … not found"** warning. The generated
+entries inherit version-sensitive instructions and tool formats from the
+installed Codex CLI. Use `--model-template <MODEL>` to select a different
+bundled model as that template.
 
 If you prefer to write the config by hand, here is the minimal form:
 
 ```toml
 model = "deepseek-chat"
 model_provider = "deepseek-relay"
+model_catalog_json = "/home/user/.codex/codex-relay-models.json"
 
 [model_providers.deepseek-relay]
 name = "DeepSeek"
 base_url = "http://127.0.0.1:4446/v1"
 wire_api = "responses"
 env_key = "DEEPSEEK_API_KEY"
-
-[model_properties."deepseek-chat"]
-context_window = 262144
-max_context_window = 1048576
-supports_parallel_tool_calls = true
-supports_reasoning_summaries = false
-input_modalities = ["text"]
 ```
 
-> ⚠️ **Without `model_properties`**, Codex CLI defaults to fallback metadata
-> for any model it doesn't recognize natively. This can degrade performance,
-> tool-call reliability, and context-window management. The relay logs a
-> reminder at startup and offers `--print-config` to eliminate this class
-> of problem entirely.
+> Recent Codex versions use `model_catalog_json`; the former
+> `[model_properties]` config syntax is no longer supported. A custom catalog
+> replaces the built-in catalog, so `codex-relay` starts with the catalog from
+> your installed Codex version and appends upstream models instead of creating
+> an incomplete replacement.
 
 **3. Use Codex normally** — it routes through the relay transparently.
 
@@ -85,7 +83,9 @@ input_modalities = ["text"]
 | `--upstream-extra-params` | `CODEX_RELAY_UPSTREAM_EXTRA_PARAMS` | _(empty)_ | JSON object merged into each upstream Chat Completions request |
 | `--drop-upstream-params` | `CODEX_RELAY_DROP_PARAMS` | _(empty)_ | JSON array of top-level upstream request parameters to remove |
 | `--model-map` | `CODEX_RELAY_MODEL_MAP` | _(empty)_ | Comma-separated `source:target` model name translations |
-| `--print-config` | _(none)_ | — | Print a Codex config snippet with `model_properties` and exit |
+| `--print-config` | _(none)_ | — | Print a Codex config snippet and exit |
+| `--model-catalog` | _(none)_ | — | With `--print-config`, write a version-matched full model catalog to this path |
+| `--model-template` | _(none)_ | first visible bundled model | Bundled Codex model whose instructions and tool formats generated entries inherit |
 | `--record-corpus` | `CODEX_RELAY_RECORD_CORPUS` | _(off)_ | Append the conversation flow of every completed turn to daily JSONL files (OpenAI messages format) in this directory |
 | `--session-ttl-hours` | `CODEX_RELAY_SESSION_TTL_HOURS` | `168` | Retain idle `previous_response_id` history and reasoning state for this many hours |
 | `--max-sessions` | `CODEX_RELAY_MAX_SESSIONS` | `256` | Maximum completed response histories retained for continuation |

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod translate;
 mod types;
 mod upstream_request;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use axum::{
     extract::{DefaultBodyLimit, Request, State},
     http::StatusCode,
@@ -20,7 +20,7 @@ use clap::Parser;
 use corpus::CorpusRecorder;
 use reqwest::{Client, Url};
 use session::{SessionStore, DEFAULT_MAX_SESSIONS, DEFAULT_MAX_SESSION_BYTES, DEFAULT_SESSION_TTL};
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{fs, path::PathBuf, process::Command, sync::Arc, time::Duration};
 use tracing::{debug, error, info, warn};
 use types::*;
 use upstream_request::UpstreamRequestConfig;
@@ -59,10 +59,17 @@ struct Args {
     #[arg(long, env = "CODEX_RELAY_DROP_PARAMS")]
     drop_upstream_params: Option<String>,
 
-    /// Print a ready-to-use Codex config.toml snippet (including model_properties)
-    /// for all models exposed by the upstream provider.
+    /// Print a ready-to-use Codex config.toml snippet.
     #[arg(long)]
     print_config: bool,
+
+    /// Write a version-matched Codex model catalog and reference it from --print-config.
+    #[arg(long, requires = "print_config", value_name = "PATH")]
+    model_catalog: Option<PathBuf>,
+
+    /// Bundled Codex model whose tool protocol and instructions custom models inherit.
+    #[arg(long, requires = "model_catalog", value_name = "MODEL")]
+    model_template: Option<String>,
 
     /// Maximum completed response histories retained for previous_response_id.
     #[arg(
@@ -151,7 +158,15 @@ async fn main() -> Result<()> {
                     .trim_end_matches(".io")
             })
             .unwrap_or("custom");
-        print_codex_config(&client, &upstream, &api_key, provider_name).await;
+        print_codex_config(
+            &client,
+            &upstream,
+            &api_key,
+            provider_name,
+            args.model_catalog.as_deref(),
+            args.model_template.as_deref(),
+        )
+        .await?;
         return Ok(());
     }
 
@@ -278,7 +293,7 @@ async fn log_upstream_models(client: Client, upstream: Arc<Url>, api_key: Arc<St
                 if !models.is_empty() {
                     info!("upstream models: {}", models.join(", "));
                     info!(
-                        "⚠️  To configure Codex with model metadata, run:  codex-relay --print-config --upstream {} {}",
+                        "⚠️  To configure Codex with model metadata, run:  codex-relay --print-config --model-catalog ~/.codex/codex-relay-models.json --upstream {} {}",
                         upstream.as_str(),
                         if api_key.is_empty() { "" } else { "--api-key ..." }
                     );
@@ -302,9 +317,16 @@ async fn cleanup_sessions(sessions: SessionStore) {
     }
 }
 
-/// Print a Codex config.toml snippet that includes model_properties for all
-/// upstream models, so users can avoid "model metadata not found" warnings.
-async fn print_codex_config(client: &Client, upstream: &Url, api_key: &str, provider_name: &str) {
+/// Print a Codex config.toml snippet and optionally generate the full model
+/// catalog required by recent Codex versions.
+async fn print_codex_config(
+    client: &Client,
+    upstream: &Url,
+    api_key: &str,
+    provider_name: &str,
+    model_catalog_path: Option<&std::path::Path>,
+    model_template: Option<&str>,
+) -> Result<()> {
     let url = format!("{}models", join_base(upstream));
     let mut builder = client.get(&url);
     if !api_key.is_empty() {
@@ -336,45 +358,202 @@ async fn print_codex_config(client: &Client, upstream: &Url, api_key: &str, prov
         }
     };
 
+    if let Some(path) = model_catalog_path {
+        let bundled = load_bundled_codex_catalog()?;
+        let catalog = build_model_catalog(bundled, &models, model_template, provider_name)?;
+        let bytes = serde_json::to_vec_pretty(&catalog)?;
+        fs::write(path, bytes)
+            .with_context(|| format!("failed to write model catalog to {}", path.display()))?;
+    }
+
     println!(
         "# ── Codex config snippet for {} ──",
         upstream.host_str().unwrap_or("custom")
     );
     println!("# Copy the lines below into ~/.codex/config.toml");
     println!();
-    println!("model_provider = \"{provider_name}\"");
+    println!("model_provider = {}", toml_string(provider_name)?);
 
     if !models.is_empty() && !models[0].starts_with('<') {
-        println!("model = \"{}\"", models[0]);
+        println!("model = {}", toml_string(&models[0])?);
     } else {
         println!("model = \"<CHOOSE_A_MODEL>\"");
     }
+    if let Some(path) = model_catalog_path {
+        let absolute = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(path)
+        };
+        let absolute = absolute
+            .to_str()
+            .context("model catalog path is not valid UTF-8")?;
+        println!("model_catalog_json = {}", toml_string(absolute)?);
+    } else {
+        println!("# To register upstream models in Codex's model picker, rerun with:");
+        println!("#   --model-catalog ~/.codex/codex-relay-models.json");
+    }
     println!();
-    println!("[model_providers.{provider_name}]");
-    println!("name = \"{}\"", provider_name);
-    println!("base_url = \"{}\"", upstream.as_str().trim_end_matches('/'));
-    println!("wire_api = \"responses\"");
+    println!("[model_providers.{}]", toml_string(provider_name)?);
+    println!("name = {}", toml_string(provider_name)?);
     println!(
-        "env_key = \"{}_API_KEY\"",
+        "base_url = {}",
+        toml_string(upstream.as_str().trim_end_matches('/'))?
+    );
+    println!("wire_api = \"responses\"");
+    let env_key = format!(
+        "{}_API_KEY",
         provider_name.to_uppercase().replace(['-', '.'], "_")
     );
+    println!("env_key = {}", toml_string(&env_key)?);
     println!();
+    Ok(())
+}
 
-    for model in &models {
-        let props = estimate_model_properties(model);
-        println!("[model_properties.\"{}\"]", model);
-        println!("context_window = {}", props.context_window);
-        println!("max_context_window = {}", props.max_context_window);
-        println!(
-            "supports_parallel_tool_calls = {}",
-            props.supports_parallel_tool_calls
+fn toml_string(value: &str) -> Result<String> {
+    serde_json::to_string(value).context("failed to quote TOML string")
+}
+
+fn load_bundled_codex_catalog() -> Result<serde_json::Value> {
+    let output = Command::new("codex")
+        .args(["debug", "models", "--bundled"])
+        .output()
+        .context("failed to run `codex debug models --bundled`; install Codex CLI or omit --model-catalog")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("`codex debug models --bundled` failed: {}", stderr.trim());
+    }
+    serde_json::from_slice(&output.stdout)
+        .context("failed to parse the bundled model catalog from the installed Codex CLI")
+}
+
+fn build_model_catalog(
+    mut catalog: serde_json::Value,
+    upstream_models: &[String],
+    template_slug: Option<&str>,
+    provider_name: &str,
+) -> Result<serde_json::Value> {
+    let models = catalog
+        .get_mut("models")
+        .and_then(serde_json::Value::as_array_mut)
+        .context("the installed Codex CLI returned a catalog without a models array")?;
+    let template = if let Some(slug) = template_slug {
+        models
+            .iter()
+            .find(|model| model.get("slug").and_then(serde_json::Value::as_str) == Some(slug))
+            .cloned()
+            .with_context(|| {
+                format!("model template `{slug}` was not found in the bundled catalog")
+            })?
+    } else {
+        models
+            .iter()
+            .find(|model| {
+                model.get("visibility").and_then(serde_json::Value::as_str) == Some("list")
+            })
+            .or_else(|| models.first())
+            .cloned()
+            .context("the installed Codex CLI returned an empty bundled catalog")?
+    };
+
+    for (index, slug) in upstream_models.iter().enumerate() {
+        if slug.starts_with('<') {
+            continue;
+        }
+        let existing_index = models
+            .iter()
+            .position(|model| model.get("slug").and_then(serde_json::Value::as_str) == Some(slug));
+        let props = estimate_model_properties(slug);
+        let mut model = template.clone();
+        let object = model
+            .as_object_mut()
+            .context("the bundled model template was not a JSON object")?;
+        object.insert("slug".into(), serde_json::Value::String(slug.clone()));
+        object.insert(
+            "display_name".into(),
+            serde_json::Value::String(slug.clone()),
         );
-        println!(
-            "supports_reasoning_summaries = {}",
-            props.supports_reasoning_summaries
+        object.insert(
+            "description".into(),
+            serde_json::Value::String(format!("{slug} via {provider_name}")),
         );
-        println!("input_modalities = [\"text\"]");
-        println!();
+        object.insert(
+            "visibility".into(),
+            serde_json::Value::String("list".into()),
+        );
+        object.insert("supported_in_api".into(), serde_json::Value::Bool(true));
+        object.insert("priority".into(), serde_json::json!(10_000 + index));
+        object.insert(
+            "context_window".into(),
+            serde_json::json!(props.context_window),
+        );
+        object.insert(
+            "max_context_window".into(),
+            serde_json::json!(props.max_context_window),
+        );
+        object.insert(
+            "supports_parallel_tool_calls".into(),
+            serde_json::Value::Bool(props.supports_parallel_tool_calls),
+        );
+        set_existing(
+            object,
+            "supports_reasoning_summaries",
+            serde_json::Value::Bool(props.supports_reasoning_summaries),
+        );
+        set_existing(
+            object,
+            "supports_reasoning_summary_parameter",
+            serde_json::Value::Bool(props.supports_reasoning_summaries),
+        );
+        object.insert("input_modalities".into(), serde_json::json!(["text"]));
+
+        // Preserve version-sensitive instructions and tool encodings from the
+        // template, while disabling capabilities the relay does not promise.
+        set_existing(object, "prefer_websockets", serde_json::Value::Bool(false));
+        object.insert("support_verbosity".into(), serde_json::Value::Bool(false));
+        object.insert("default_verbosity".into(), serde_json::Value::Null);
+        object.insert("default_reasoning_level".into(), serde_json::Value::Null);
+        object.insert("supported_reasoning_levels".into(), serde_json::json!([]));
+        set_existing(
+            object,
+            "supports_image_detail_original",
+            serde_json::Value::Bool(false),
+        );
+        object.insert(
+            "supports_search_tool".into(),
+            serde_json::Value::Bool(false),
+        );
+        object.insert("use_responses_lite".into(), serde_json::Value::Bool(false));
+        object.insert("tool_mode".into(), serde_json::Value::Null);
+        object.insert("multi_agent_version".into(), serde_json::Value::Null);
+        object.insert("experimental_supported_tools".into(), serde_json::json!([]));
+        object.insert("additional_speed_tiers".into(), serde_json::json!([]));
+        object.insert("service_tiers".into(), serde_json::json!([]));
+        object.insert("default_service_tier".into(), serde_json::Value::Null);
+        object.insert("availability_nux".into(), serde_json::Value::Null);
+        object.insert("upgrade".into(), serde_json::Value::Null);
+        object.insert("auto_review_model_override".into(), serde_json::Value::Null);
+        object.insert("auto_compact_token_limit".into(), serde_json::Value::Null);
+        object.insert("comp_hash".into(), serde_json::Value::Null);
+        object.remove("minimal_client_version");
+        object.remove("available_in_plans");
+        if let Some(index) = existing_index {
+            models[index] = model;
+        } else {
+            models.push(model);
+        }
+    }
+
+    Ok(catalog)
+}
+
+fn set_existing(
+    object: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    value: serde_json::Value,
+) {
+    if object.contains_key(key) {
+        object.insert(key.into(), value);
     }
 }
 
@@ -1523,5 +1702,126 @@ mod tests {
         assert_eq!(props.max_context_window, 128_000);
         assert!(!props.supports_reasoning_summaries);
         assert!(props.supports_parallel_tool_calls);
+    }
+
+    #[test]
+    fn test_toml_string_quotes_untrusted_model_ids() {
+        assert_eq!(
+            toml_string("model\"\nnotify = [\"bad\"]").unwrap(),
+            "\"model\\\"\\nnotify = [\\\"bad\\\"]\""
+        );
+    }
+
+    #[test]
+    fn test_build_model_catalog_preserves_bundled_models_and_template_protocol() {
+        let bundled = serde_json::json!({
+            "models": [{
+                "slug": "codex-template",
+                "display_name": "Codex Template",
+                "description": "bundled",
+                "visibility": "list",
+                "supported_in_api": true,
+                "priority": 1,
+                "base_instructions": "version-matched instructions",
+                "model_messages": {"instructions_template": "version-matched template"},
+                "shell_type": "shell_command",
+                "apply_patch_tool_type": "freeform",
+                "prefer_websockets": true,
+                "support_verbosity": true,
+                "default_verbosity": "medium",
+                "default_reasoning_level": "high",
+                "supported_reasoning_levels": [{"effort": "high", "description": "deep"}],
+                "supports_reasoning_summaries": true,
+                "supports_reasoning_summary_parameter": true,
+                "supports_search_tool": true,
+                "supports_image_detail_original": true,
+                "use_responses_lite": true,
+                "tool_mode": "code_mode_only",
+                "multi_agent_version": "v2",
+                "experimental_supported_tools": ["unknown"],
+                "additional_speed_tiers": ["fast"],
+                "service_tiers": [{"id": "fast"}],
+                "availability_nux": {"message": "new"},
+                "upgrade": {"id": "next"},
+                "comp_hash": "template-only"
+            }]
+        });
+
+        let catalog = build_model_catalog(
+            bundled,
+            &["deepseek-r1".into()],
+            Some("codex-template"),
+            "provider",
+        )
+        .unwrap();
+        let models = catalog["models"].as_array().unwrap();
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0]["slug"], "codex-template");
+        let generated = &models[1];
+        assert_eq!(generated["slug"], "deepseek-r1");
+        assert_eq!(
+            generated["base_instructions"],
+            "version-matched instructions"
+        );
+        assert_eq!(
+            generated["model_messages"]["instructions_template"],
+            "version-matched template"
+        );
+        assert_eq!(generated["shell_type"], "shell_command");
+        assert_eq!(generated["apply_patch_tool_type"], "freeform");
+        assert_eq!(generated["prefer_websockets"], false);
+        assert_eq!(
+            generated["supported_reasoning_levels"],
+            serde_json::json!([])
+        );
+        assert_eq!(generated["supports_reasoning_summaries"], true);
+        assert_eq!(generated["supports_reasoning_summary_parameter"], true);
+        assert_eq!(generated["supports_image_detail_original"], false);
+        assert_eq!(generated["context_window"], 262_144);
+        assert_eq!(generated["tool_mode"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn test_build_model_catalog_sanitizes_bundled_slug_collision() {
+        let bundled = serde_json::json!({"models": [{
+            "slug": "same-model",
+            "display_name": "Bundled",
+            "visibility": "list",
+            "prefer_websockets": true,
+            "supports_reasoning_summary_parameter": true,
+            "supports_search_tool": true,
+            "supports_image_detail_original": true,
+            "use_responses_lite": true,
+            "tool_mode": "code_mode_only",
+            "multi_agent_version": "v2"
+        }]});
+
+        let catalog = build_model_catalog(
+            bundled,
+            &["same-model".into()],
+            Some("same-model"),
+            "provider",
+        )
+        .unwrap();
+        let models = catalog["models"].as_array().unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0]["display_name"], "same-model");
+        assert_eq!(models[0]["prefer_websockets"], false);
+        assert_eq!(models[0]["supports_reasoning_summary_parameter"], false);
+        assert_eq!(models[0]["supports_search_tool"], false);
+        assert_eq!(models[0]["supports_image_detail_original"], false);
+        assert_eq!(models[0]["use_responses_lite"], false);
+        assert_eq!(models[0]["tool_mode"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn test_build_model_catalog_rejects_unknown_template() {
+        let bundled = serde_json::json!({"models": [{
+            "slug": "known",
+            "visibility": "list"
+        }]});
+        let error = build_model_catalog(bundled, &["upstream".into()], Some("missing"), "provider")
+            .unwrap_err();
+        assert!(error.to_string().contains("was not found"));
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -17,9 +17,9 @@ use crate::{
     session::SessionStore,
     think::ThinkStreamFilter,
     translate::{
-        allowed_upstream_tool_names, custom_tool_input, response_function_name_for_responses,
-        uses_plaintext_collaboration_args, validate_tool_call_entries, CustomToolMap,
-        NamespaceToolMap,
+        allowed_upstream_tool_names, completed_tool_arguments, custom_tool_input,
+        response_function_name_for_responses, uses_plaintext_collaboration_args,
+        validate_tool_call_entries, CustomToolMap, NamespaceToolMap,
     },
     types::{ChatMessage, ChatRequest, ChatStreamChunk, ChatUsage},
     upstream_request::UpstreamRequestConfig,
@@ -556,6 +556,7 @@ pub fn translate_stream(
             let output_index = base_index + rel_idx;
             let (namespace, name) = response_function_name_for_responses(&tc.name, &namespace_tools);
             let custom = custom_tools.get(&tc.name);
+            let arguments = completed_tool_arguments(&tc.arguments);
             let fc_item_id = if custom.is_some() {
                 format!("ctc_{}", uuid::Uuid::new_v4().simple())
             } else {
@@ -596,7 +597,7 @@ pub fn translate_stream(
                     "id": &fc_item_id,
                     "call_id": &tc.id,
                     "name": &name,
-                    "arguments": &tc.arguments,
+                    "arguments": arguments,
                     "status": "completed"
                 });
                 if let Some(namespace) = namespace {
@@ -667,7 +668,10 @@ pub fn translate_stream(
                 Some(tool_calls.values().map(|tc| json!({
                     "id": &tc.id,
                     "type": "function",
-                    "function": { "name": &tc.name, "arguments": &tc.arguments }
+                    "function": {
+                        "name": &tc.name,
+                        "arguments": completed_tool_arguments(&tc.arguments)
+                    }
                 })).collect())
             };
             let assistant_msg = ChatMessage {

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -50,6 +50,12 @@ pub fn to_chat_request(
 ) -> ChatRequest {
     let mut messages = history;
 
+    // Repair sessions persisted by older relay versions before their invalid
+    // empty argument strings are replayed to a strict upstream provider.
+    for message in &mut messages {
+        complete_message_tool_arguments(message);
+    }
+
     // History can contain poison blank messages from an earlier turn. Remove
     // them before deciding whether an existing system prompt suppresses the
     // current request's instructions. Keep the newest one as a fallback in
@@ -176,6 +182,7 @@ pub fn to_chat_request(
                         } else {
                             cur.get("arguments")
                                 .and_then(Value::as_str)
+                                .map(completed_tool_arguments)
                                 .unwrap_or("{}")
                                 .to_string()
                         };
@@ -457,6 +464,37 @@ pub(crate) fn validate_tool_call_entries<'a>(
     Ok(())
 }
 
+/// Chat Completions providers may omit the arguments delta for a function
+/// whose schema has no parameters. Completed Responses items and replayed
+/// Chat Completions history still require the value to contain valid JSON.
+pub(crate) fn completed_tool_arguments(arguments: &str) -> &str {
+    if arguments.trim().is_empty() {
+        "{}"
+    } else {
+        arguments
+    }
+}
+
+fn complete_message_tool_arguments(message: &mut ChatMessage) {
+    let Some(tool_calls) = message.tool_calls.as_mut() else {
+        return;
+    };
+    for tool_call in tool_calls {
+        let Some(function) = tool_call.get_mut("function").and_then(Value::as_object_mut) else {
+            continue;
+        };
+        match function.get("arguments") {
+            Some(Value::String(arguments)) if arguments.trim().is_empty() => {
+                function.insert("arguments".into(), Value::String("{}".into()));
+            }
+            None => {
+                function.insert("arguments".into(), Value::String("{}".into()));
+            }
+            Some(_) => {}
+        }
+    }
+}
+
 fn declared_function_name(tool: &Value) -> Option<&str> {
     tool.get("name").and_then(Value::as_str).or_else(|| {
         tool.get("function")
@@ -730,10 +768,10 @@ pub fn from_chat_response_with_tool_maps(
             let function = tool_call.get("function").unwrap_or(&Value::Null);
             let raw_name = function.get("name").and_then(Value::as_str).unwrap_or("");
             let (namespace, name) = response_function_name_for_responses(raw_name, namespace_tools);
-            let arguments = function
+            let raw_arguments = function
                 .get("arguments")
                 .and_then(Value::as_str)
-                .unwrap_or("{}");
+                .unwrap_or("");
             let call_id = tool_call.get("id").and_then(Value::as_str).unwrap_or("");
             let item = if let Some(custom) = custom_tools.get(raw_name) {
                 json!({
@@ -741,10 +779,11 @@ pub fn from_chat_response_with_tool_maps(
                     "id": format!("ctc_{}", uuid::Uuid::new_v4().simple()),
                     "call_id": call_id,
                     "name": custom.name,
-                    "input": custom_tool_input(arguments, &custom.argument_field),
+                    "input": custom_tool_input(raw_arguments, &custom.argument_field),
                     "status": "completed"
                 })
             } else {
+                let arguments = completed_tool_arguments(raw_arguments);
                 let mut item = json!({
                     "type": "function_call",
                     "id": format!("fc_{}", uuid::Uuid::new_v4().simple()),
@@ -780,6 +819,7 @@ pub fn from_chat_response_with_tool_maps(
         },
     };
 
+    complete_message_tool_arguments(&mut choice.message);
     (response, vec![choice.message])
 }
 
@@ -1755,6 +1795,152 @@ mod tests {
             &allowed
         )
         .is_ok());
+    }
+
+    #[test]
+    fn test_empty_completed_tool_arguments_become_json_object() {
+        assert_eq!(completed_tool_arguments(""), "{}");
+        assert_eq!(completed_tool_arguments(" \n\t"), "{}");
+        assert_eq!(completed_tool_arguments("{malformed"), "{malformed");
+    }
+
+    #[test]
+    fn test_non_string_tool_arguments_are_not_silently_rewritten() {
+        let mut message = ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            reasoning_content: None,
+            tool_calls: Some(vec![json!({
+                "id": "call_bad",
+                "type": "function",
+                "function": {"name": "bad", "arguments": {"unexpected": true}}
+            })]),
+            tool_call_id: None,
+            name: None,
+        };
+
+        complete_message_tool_arguments(&mut message);
+        assert_eq!(
+            message.tool_calls.as_ref().unwrap()[0]["function"]["arguments"],
+            json!({"unexpected": true})
+        );
+    }
+
+    #[test]
+    fn test_empty_function_call_arguments_are_repaired_during_replay() {
+        let sessions = SessionStore::new();
+        let req = base_req(ResponsesInput::Messages(vec![json!({
+            "type": "function_call",
+            "call_id": "call_empty",
+            "name": "no_args",
+            "arguments": ""
+        })]));
+
+        let chat = to_chat_request(&req, vec![], &sessions);
+        assert_eq!(
+            chat.messages[0].tool_calls.as_ref().unwrap()[0]["function"]["arguments"],
+            "{}"
+        );
+    }
+
+    #[test]
+    fn test_empty_arguments_in_retained_history_are_repaired_before_duplicate_input() {
+        let sessions = SessionStore::new();
+        let history = vec![ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            reasoning_content: None,
+            tool_calls: Some(vec![json!({
+                "id": "call_old",
+                "type": "function",
+                "function": {"name": "no_args", "arguments": ""}
+            })]),
+            tool_call_id: None,
+            name: None,
+        }];
+        let req = base_req(ResponsesInput::Messages(vec![json!({
+            "type": "function_call",
+            "call_id": "call_old",
+            "name": "no_args",
+            "arguments": ""
+        })]));
+
+        let chat = to_chat_request(&req, history, &sessions);
+        assert_eq!(
+            chat.messages.len(),
+            1,
+            "duplicate input call must be skipped"
+        );
+        assert_eq!(
+            chat.messages[0].tool_calls.as_ref().unwrap()[0]["function"]["arguments"],
+            "{}"
+        );
+    }
+
+    #[test]
+    fn test_empty_blocking_tool_arguments_are_completed_as_json_object() {
+        let chat = ChatResponse {
+            choices: vec![ChatChoice {
+                message: ChatMessage {
+                    role: "assistant".into(),
+                    content: None,
+                    reasoning_content: None,
+                    tool_calls: Some(vec![json!({
+                        "id": "call_empty",
+                        "type": "function",
+                        "function": {"name": "no_args", "arguments": ""}
+                    })]),
+                    tool_call_id: None,
+                    name: None,
+                },
+            }],
+            usage: None,
+        };
+
+        let (response, history) = from_chat_response("resp_empty".into(), "model", chat);
+        assert_eq!(response.output[0]["arguments"], "{}");
+        assert_eq!(
+            history[0].tool_calls.as_ref().unwrap()[0]["function"]["arguments"],
+            "{}"
+        );
+    }
+
+    #[test]
+    fn test_empty_blocking_custom_tool_arguments_remain_empty_input() {
+        let tools = vec![json!({"type": "custom", "name": "custom_empty"})];
+        let custom_tools = custom_tool_map(&tools);
+        let chat = ChatResponse {
+            choices: vec![ChatChoice {
+                message: ChatMessage {
+                    role: "assistant".into(),
+                    content: None,
+                    reasoning_content: None,
+                    tool_calls: Some(vec![json!({
+                        "id": "call_custom",
+                        "type": "function",
+                        "function": {"name": "custom_empty", "arguments": ""}
+                    })]),
+                    tool_call_id: None,
+                    name: None,
+                },
+            }],
+            usage: None,
+        };
+
+        let (response, history) = from_chat_response_with_tool_maps(
+            "resp_custom".into(),
+            "model",
+            chat,
+            &NamespaceToolMap::new(),
+            &custom_tools,
+        );
+        assert_eq!(response.output[0]["type"], "custom_tool_call");
+        assert_eq!(response.output[0]["input"], "");
+        assert_eq!(
+            history[0].tool_calls.as_ref().unwrap()[0]["function"]["arguments"],
+            "{}",
+            "chat history still requires valid JSON"
+        );
     }
 
     #[test]

--- a/tests/regression_issues.rs
+++ b/tests/regression_issues.rs
@@ -1707,6 +1707,76 @@ async fn issue_17_streaming_namespaced_tool_calls_emit_namespace_field() {
 }
 
 #[tokio::test]
+async fn issue_57_streaming_zero_argument_tool_call_is_valid_json_and_replays() {
+    let tool_sse = sse_from_chunks(vec![json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "id": "call_no_args",
+                    "function": {"name": "no_args"}
+                }]
+            }
+        }]
+    })]);
+    let (upstream_port, bodies) =
+        spawn_mock_upstream_with_responses(vec![tool_sse, default_ok_sse()]).await;
+    let relay = Relay::spawn(&format!("http://127.0.0.1:{upstream_port}/v1"));
+    let tool = json!({
+        "type": "function",
+        "name": "no_args",
+        "parameters": {"type": "object", "properties": {}}
+    });
+
+    let events = post_stream_events(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "input": "Call it.",
+            "tools": [tool.clone()],
+            "stream": true
+        }),
+    )
+    .await;
+    let done = events
+        .iter()
+        .find(|(event, data)| {
+            event == "response.output_item.done" && data["item"]["type"] == "function_call"
+        })
+        .map(|(_, data)| &data["item"])
+        .expect("function_call done item");
+    assert_eq!(done["arguments"], "{}");
+    let completed = events
+        .iter()
+        .find_map(|(event, data)| (event == "response.completed").then_some(data))
+        .expect("response.completed");
+    assert_eq!(completed["response"]["output"][0]["arguments"], "{}");
+    let response_id = completed["response"]["id"].as_str().unwrap();
+
+    post_stream_completed(
+        &relay,
+        json!({
+            "model": "mock-model",
+            "previous_response_id": response_id,
+            "input": [{
+                "type": "function_call_output",
+                "call_id": "call_no_args",
+                "output": "done"
+            }],
+            "tools": [tool],
+            "stream": true
+        }),
+    )
+    .await;
+
+    let requests = bodies.lock().unwrap();
+    assert_eq!(
+        requests[1]["messages"][1]["tool_calls"][0]["function"]["arguments"], "{}",
+        "persisted tool calls must replay with valid JSON arguments"
+    );
+}
+
+#[tokio::test]
 async fn issue_43_streaming_collaboration_calls_request_plaintext_arguments() {
     let tool_sse = sse_from_chunks(vec![
         json!({


### PR DESCRIPTION
## Summary

- normalize empty completed function arguments to valid JSON across streaming, blocking, persistence, and replay paths
- repair retained histories created by older relay versions without rewriting non-empty malformed values
- replace obsolete `model_properties` output with a version-matched `model_catalog_json` generator
- preserve the installed Codex catalog and version-sensitive instructions/tool encodings while disabling unsupported inherited capabilities
- quote generated TOML values and safely handle bundled/upstream slug collisions

## Design and safety

For zero-argument calls, only missing or blank string arguments become `{}`. Non-empty malformed strings and non-string values remain visible to strict upstream validation. Custom-tool plaintext input remains unchanged while persisted Chat Completions history stays valid JSON.

For model metadata, the generator calls `codex debug models --bundled` from the user's installed CLI, retains all bundled models, and derives custom entries from a selectable bundled template. This avoids empty or stale Codex instructions and supports schema differences between Codex versions.

## Verification

- `cargo test` (364 passed; 12 live tests ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt -- --check`
- generated catalog loaded successfully through the installed Codex CLI
- two rounds of focused safety review; no remaining release blockers

Closes #57
Closes #58