### PR TITLE
Add opt-in OpenCode Go compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,14 +163,18 @@ JSON Schema `$ref` nodes in tool definitions. These workarounds are opt-in
 because schema stripping is provider-specific and can change tool semantics:
 
 ```bash
-CODEX_RELAY_OPENCODE_GO_COMPAT=1 \
+CODEX_RELAY_OPENCODE_GO_COMPAT=true \
   codex-relay --upstream https://opencode.ai/zen/go/v1 --api-key "$OPENCODE_GO_API_KEY"
 ```
 
-The feature converts orphan tool outputs into developer messages before the
-normal Responses-to-Chat-Completions translation and removes only the affected
-`$ref` schema nodes. It logs how many nodes were changed without logging
-request content or credentials.
+The feature forwards Muse requests to OpenCode Go's native `/responses`
+endpoint. It converts orphan tool outputs and custom tools into supported
+Responses items, flattens namespace tools, removes unsupported built-in tool
+fields and recursive `$ref` schema nodes, and drops `reasoning.effort=none`.
+It logs only change counts, without request content or credentials. The relay
+also forwards an incoming `x-opencode-session` header, or generates a bounded
+stable fallback and binds it to the upstream response ID for subsequent
+`previous_response_id` requests.
 
 Some providers need workarounds that are not part of the Responses ⇄ Chat Completions translation itself. These are registered as named quirks (see `src/quirks.rs` for the full registry, triggers, and removal criteria):
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ env_key = "DEEPSEEK_API_KEY"
 | `--bind` | `CODEX_RELAY_BIND` | `127.0.0.1` | IP address to bind the listener to (e.g. `0.0.0.0` to accept remote connections) |
 | `--upstream` | `CODEX_RELAY_UPSTREAM` | `https://openrouter.ai/api/v1` | Upstream Chat Completions base URL |
 | `--api-key` | `CODEX_RELAY_API_KEY` | _(empty)_ | API key forwarded to upstream |
+| `--opencode-go-compat` | `CODEX_RELAY_OPENCODE_GO_COMPAT` | `false` | Enable OpenCode Go compatibility normalization and schema-reference stripping |
+| `--max-request-bytes` | `CODEX_RELAY_MAX_REQUEST_BYTES` | `67108864` | Maximum inbound Responses request size |
 | `--upstream-extra-params` | `CODEX_RELAY_UPSTREAM_EXTRA_PARAMS` | _(empty)_ | JSON object merged into each upstream Chat Completions request |
 | `--drop-upstream-params` | `CODEX_RELAY_DROP_PARAMS` | _(empty)_ | JSON array of top-level upstream request parameters to remove |
 | `--model-map` | `CODEX_RELAY_MODEL_MAP` | _(empty)_ | Comma-separated `source:target` model name translations |
@@ -136,6 +138,8 @@ codex-relay --upstream https://api.deepseek.com/v1 --api-key "$DEEPSEEK_API_KEY"
 | `CODEX_RELAY_BIND` | `127.0.0.1` | IP address to bind the listener to (e.g. `0.0.0.0` to accept remote connections) |
 | `CODEX_RELAY_UPSTREAM` | `https://openrouter.ai/api/v1` | Upstream Chat Completions base URL |
 | `CODEX_RELAY_API_KEY` | _(empty)_ | API key forwarded to upstream |
+| `CODEX_RELAY_OPENCODE_GO_COMPAT` | `false` | Enable OpenCode Go compatibility normalization and schema-reference stripping |
+| `CODEX_RELAY_MAX_REQUEST_BYTES` | `67108864` | Maximum inbound Responses request size |
 | `CODEX_RELAY_UPSTREAM_EXTRA_PARAMS` | _(empty)_ | JSON object merged into each upstream Chat Completions request body |
 | `CODEX_RELAY_DROP_PARAMS` | _(empty)_ | JSON array of top-level upstream request parameter names to remove before forwarding |
 | `CODEX_RELAY_MODEL_MAP` | _(empty)_ | Comma-separated `source:target` model name translations (e.g., `gpt-5.4:deepseek-v4-pro`) |
@@ -150,6 +154,23 @@ codex-relay --upstream https://api.deepseek.com/v1 --api-key "$DEEPSEEK_API_KEY"
 | `RUST_LOG` | `codex_relay=info` | Log verbosity |
 
 ## Platform quirks
+
+### OpenCode Go compatibility
+
+OpenCode Go can reject two otherwise valid Codex request patterns: standalone
+`function_call_output` items without a `call_id`, and recursive or unsupported
+JSON Schema `$ref` nodes in tool definitions. These workarounds are opt-in
+because schema stripping is provider-specific and can change tool semantics:
+
+```bash
+CODEX_RELAY_OPENCODE_GO_COMPAT=1 \
+  codex-relay --upstream https://opencode.ai/zen/go/v1 --api-key "$OPENCODE_GO_API_KEY"
+```
+
+The feature converts orphan tool outputs into developer messages before the
+normal Responses-to-Chat-Completions translation and removes only the affected
+`$ref` schema nodes. It logs how many nodes were changed without logging
+request content or credentials.
 
 Some providers need workarounds that are not part of the Responses ⇄ Chat Completions translation itself. These are registered as named quirks (see `src/quirks.rs` for the full registry, triggers, and removal criteria):
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use types::*;
 use upstream_request::UpstreamRequestConfig;
 
 const DEBUG_NAME_LIMIT: usize = 80;
+const DEFAULT_MAX_REQUEST_BYTES: usize = 64 * 1024 * 1024;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -50,6 +51,18 @@ struct Args {
 
     #[arg(long, env = "CODEX_RELAY_API_KEY", default_value = "")]
     api_key: String,
+
+    /// Enable compatibility workarounds for the OpenCode Go Responses endpoint.
+    #[arg(long, env = "CODEX_RELAY_OPENCODE_GO_COMPAT", default_value_t = false)]
+    opencode_go_compat: bool,
+
+    /// Maximum inbound Responses request size in bytes.
+    #[arg(
+        long,
+        env = "CODEX_RELAY_MAX_REQUEST_BYTES",
+        default_value_t = DEFAULT_MAX_REQUEST_BYTES
+    )]
+    max_request_bytes: usize,
 
     /// JSON object merged into every upstream Chat Completions request body.
     #[arg(long, env = "CODEX_RELAY_UPSTREAM_EXTRA_PARAMS")]
@@ -123,6 +136,7 @@ struct AppState {
     api_key: Arc<String>,
     upstream_request: Arc<UpstreamRequestConfig>,
     corpus: Option<CorpusRecorder>,
+    opencode_go_compat: bool,
 }
 
 #[tokio::main]
@@ -205,6 +219,7 @@ async fn main() -> Result<()> {
         api_key: api_key.clone(),
         upstream_request: upstream_request.clone(),
         corpus,
+        opencode_go_compat: args.opencode_go_compat,
     };
     info!(
         "session retention: store={} dir={} ttl={}h max_sessions={} max_session_memory={} MiB",
@@ -221,22 +236,23 @@ async fn main() -> Result<()> {
             upstream_request.drop_param_count()
         );
     }
+    if args.opencode_go_compat {
+        info!("OpenCode Go compatibility enabled");
+    }
 
     // Fetch upstream model list asynchronously for user visibility
     tokio::spawn(log_upstream_models(client, Arc::new(upstream), api_key));
 
     tokio::spawn(cleanup_sessions(state.sessions.clone()));
 
-    // Disable axum's default 2 MiB body cap: Codex CLI may send base64-encoded
-    // image attachments that easily exceed it, and a framework-level 413 looks
-    // like a transport-layer death to Codex and crashes the session (#2).
-    // The relay binds 127.0.0.1 by default; --bind can expose it more widely,
-    // so be mindful of DoS when binding to a non-loopback address.
+    // Codex CLI may send base64-encoded image attachments that exceed Axum's
+    // default 2 MiB cap, but an unlimited body is an avoidable DoS risk when
+    // --bind exposes the listener beyond localhost. Keep the cap configurable.
     let app = Router::new()
         .route("/v1/responses", post(handle_responses))
         .route("/v1/models", get(handle_models))
         .fallback(handle_fallback)
-        .layer(DefaultBodyLimit::disable())
+        .layer(DefaultBodyLimit::max(args.max_request_bytes))
         .with_state(state.clone());
 
     let addr = std::net::SocketAddr::new(args.bind, args.port);
@@ -808,7 +824,27 @@ async fn handle_responses_inner(state: AppState, mut req: ResponsesRequest) -> R
     let model = req.model.clone();
     let namespace_tools = translate::namespace_tool_map(&req.tools);
     let custom_tools = translate::custom_tool_map(&req.tools);
-    let mut chat_req = translate::to_chat_request(&req, history, &state.sessions);
+    let mut chat_req = if state.opencode_go_compat {
+        translate::to_chat_request_with_options(
+            &req,
+            history,
+            &state.sessions,
+            translate::TranslateOptions {
+                opencode_go_compat: true,
+            },
+        )
+    } else {
+        translate::to_chat_request(&req, history, &state.sessions)
+    };
+    if state.opencode_go_compat {
+        let stripped = translate::strip_tool_schema_refs(&mut chat_req.tools);
+        if stripped > 0 {
+            warn!(
+                "opencode_go_compat stripped {} tool schema $ref node(s)",
+                stripped
+            );
+        }
+    }
     debug!(
         "→ upstream tools={}",
         summarize_debug_names(chat_tool_debug_names(&chat_req.tools))

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,9 @@ mod upstream_request;
 
 use anyhow::{bail, Context, Result};
 use axum::{
+    body::Body,
     extract::{DefaultBodyLimit, Request, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
@@ -20,7 +21,14 @@ use clap::Parser;
 use corpus::CorpusRecorder;
 use reqwest::{Client, Url};
 use session::{SessionStore, DEFAULT_MAX_SESSIONS, DEFAULT_MAX_SESSION_BYTES, DEFAULT_SESSION_TTL};
-use std::{fs, path::PathBuf, process::Command, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, VecDeque},
+    fs,
+    path::PathBuf,
+    process::Command,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 use tracing::{debug, error, info, warn};
 use types::*;
 use upstream_request::UpstreamRequestConfig;
@@ -137,6 +145,61 @@ struct AppState {
     upstream_request: Arc<UpstreamRequestConfig>,
     corpus: Option<CorpusRecorder>,
     opencode_go_compat: bool,
+    opencode_sessions: OpenCodeSessionRegistry,
+}
+
+#[derive(Clone)]
+struct OpenCodeSessionRegistry {
+    state: Arc<Mutex<OpenCodeSessionState>>,
+    max_entries: usize,
+}
+
+struct OpenCodeSessionState {
+    by_response: HashMap<String, String>,
+    order: VecDeque<String>,
+}
+
+impl OpenCodeSessionRegistry {
+    fn new(max_entries: usize) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(OpenCodeSessionState {
+                by_response: HashMap::new(),
+                order: VecDeque::new(),
+            })),
+            max_entries: max_entries.max(1),
+        }
+    }
+
+    fn session_for_request(&self, previous_response_id: Option<&str>, fallback: String) -> String {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        previous_response_id
+            .and_then(|id| state.by_response.get(id))
+            .cloned()
+            .unwrap_or(fallback)
+    }
+
+    fn bind(&self, response_id: String, session_id: String) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state
+            .by_response
+            .insert(response_id.clone(), session_id)
+            .is_some()
+        {
+            state.order.retain(|id| id != &response_id);
+        }
+        state.order.push_back(response_id);
+        while state.order.len() > self.max_entries {
+            if let Some(oldest) = state.order.pop_front() {
+                state.by_response.remove(&oldest);
+            }
+        }
+    }
 }
 
 #[tokio::main]
@@ -220,6 +283,7 @@ async fn main() -> Result<()> {
         upstream_request: upstream_request.clone(),
         corpus,
         opencode_go_compat: args.opencode_go_compat,
+        opencode_sessions: OpenCodeSessionRegistry::new(args.max_sessions),
     };
     info!(
         "session retention: store={} dir={} ttl={}h max_sessions={} max_session_memory={} MiB",
@@ -771,9 +835,13 @@ fn chat_response_tool_call_debug_names(chat_resp: &ChatResponse) -> Vec<String> 
         .collect()
 }
 
-async fn handle_responses(State(state): State<AppState>, body: axum::body::Bytes) -> Response {
-    let req: ResponsesRequest = match serde_json::from_slice(&body) {
-        Ok(r) => r,
+async fn handle_responses(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let payload: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(payload) => payload,
         Err(e) => {
             error!(
                 error_category = ?e.classify(),
@@ -782,6 +850,13 @@ async fn handle_responses(State(state): State<AppState>, body: axum::body::Bytes
                 body_bytes = body.len(),
                 "JSON parse error"
             );
+            return (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response();
+        }
+    };
+    let req: ResponsesRequest = match serde_json::from_value(payload.clone()) {
+        Ok(r) => r,
+        Err(e) => {
+            error!("request shape parse error: {e}");
             return (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response();
         }
     };
@@ -801,7 +876,151 @@ async fn handle_responses(State(state): State<AppState>, body: axum::body::Bytes
         summarize_debug_names(response_tool_debug_names(&req.tools))
     );
 
+    let incoming_opencode_session = headers
+        .get("x-opencode-session")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+
+    if state.opencode_go_compat {
+        return handle_opencode_responses(state, payload, req, headers, incoming_opencode_session)
+            .await;
+    }
+
     handle_responses_inner(state, req).await
+}
+
+async fn handle_opencode_responses(
+    state: AppState,
+    mut payload: serde_json::Value,
+    req: ResponsesRequest,
+    headers: HeaderMap,
+    incoming_opencode_session: Option<String>,
+) -> Response {
+    let (normalized_outputs, stripped_refs, stripped_fields) =
+        translate::normalize_opencode_go_responses_payload(&mut payload);
+    if normalized_outputs > 0 {
+        warn!(
+            "opencode_go_compat normalized {} orphan function_call_output item(s)",
+            normalized_outputs
+        );
+    }
+    if stripped_refs > 0 {
+        warn!(
+            "opencode_go_compat stripped {} tool schema $ref node(s)",
+            stripped_refs
+        );
+    }
+    if stripped_fields > 0 {
+        warn!(
+            "opencode_go_compat stripped {} unsupported tool field(s)",
+            stripped_fields
+        );
+    }
+
+    let session_id = incoming_opencode_session.unwrap_or_else(|| {
+        state.opencode_sessions.session_for_request(
+            req.previous_response_id.as_deref(),
+            translate::opencode_session_id_for_request(&req),
+        )
+    });
+    let url = format!("{}responses", join_base(&state.upstream));
+    let mut builder = state
+        .client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .header(
+            "Accept",
+            if req.stream {
+                "text/event-stream"
+            } else {
+                "application/json"
+            },
+        )
+        .header(
+            "User-Agent",
+            format!("codex-relay/{}", env!("CARGO_PKG_VERSION")),
+        )
+        .header("x-opencode-session", session_id.as_str());
+    if !state.api_key.is_empty() {
+        builder = builder.bearer_auth(state.api_key.as_str());
+    }
+    for name in ["OpenAI-Beta", "OpenAI-Organization", "OpenAI-Project"] {
+        if let Some(value) = headers.get(name) {
+            builder = builder.header(name, value);
+        }
+    }
+
+    let upstream = match builder.json(&payload).send().await {
+        Ok(response) => response,
+        Err(e) => {
+            error!("OpenCode Go Responses request failed: {e}");
+            return (StatusCode::BAD_GATEWAY, e.to_string()).into_response();
+        }
+    };
+    let status = upstream.status();
+    let content_type = upstream.headers().get("content-type").cloned();
+    let body = match upstream.bytes().await {
+        Ok(body) => body,
+        Err(e) => {
+            error!("OpenCode Go Responses body read failed: {e}");
+            return (StatusCode::BAD_GATEWAY, e.to_string()).into_response();
+        }
+    };
+    if !status.is_success() {
+        error!("upstream {status}: OpenCode Go Responses request failed");
+        return (
+            StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY),
+            body,
+        )
+            .into_response();
+    }
+
+    if let Some(response_id) = opencode_response_id(&body, req.stream) {
+        state
+            .opencode_sessions
+            .bind(response_id, session_id.to_owned());
+    }
+
+    let mut response = Response::builder().status(status);
+    if let Some(content_type) = content_type {
+        response = response.header("content-type", content_type);
+    }
+    response
+        .body(Body::from(body))
+        .unwrap_or_else(|e| (StatusCode::BAD_GATEWAY, e.to_string()).into_response())
+}
+
+fn opencode_response_id(body: &[u8], stream: bool) -> Option<String> {
+    if !stream {
+        return serde_json::from_slice::<serde_json::Value>(body)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
+            });
+    }
+
+    body.split(|byte| *byte == b'\n')
+        .filter_map(|line| line.strip_prefix(b"data:"))
+        .filter_map(|data| {
+            let data = data.strip_prefix(b" ").unwrap_or(data);
+            serde_json::from_slice::<serde_json::Value>(data).ok()
+        })
+        .find_map(|event| {
+            (event.get("type").and_then(serde_json::Value::as_str) == Some("response.created"))
+                .then(|| {
+                    event
+                        .get("response")
+                        .and_then(|response| response.get("id"))
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_owned)
+                })
+                .flatten()
+        })
 }
 
 async fn handle_responses_inner(state: AppState, mut req: ResponsesRequest) -> Response {
@@ -852,8 +1071,8 @@ async fn handle_responses_inner(state: AppState, mut req: ResponsesRequest) -> R
     let url = format!("{}chat/completions", join_base(&state.upstream));
 
     let previous_response_id = req.previous_response_id.clone();
+    let response_id = state.sessions.new_id();
     if req.stream {
-        let response_id = state.sessions.new_id();
         chat_req.stream = true;
         let request_messages = chat_req.messages.clone();
         stream::translate_stream(stream::StreamArgs {
@@ -882,6 +1101,7 @@ async fn handle_responses_inner(state: AppState, mut req: ResponsesRequest) -> R
             namespace_tools,
             custom_tools,
             previous_response_id,
+            response_id,
         )
         .await
     }
@@ -1186,6 +1406,7 @@ async fn handle_blocking(
     namespace_tools: translate::NamespaceToolMap,
     custom_tools: translate::CustomToolMap,
     previous_response_id: Option<String>,
+    response_id: String,
 ) -> Response {
     let mut builder = state
         .client
@@ -1249,7 +1470,6 @@ async fn handle_blocking(
                         "← upstream function_calls={}",
                         summarize_debug_names(chat_response_tool_call_debug_names(&chat_resp))
                     );
-                    let response_id = state.sessions.new_id();
                     let (resp, assistant_messages) =
                         if namespace_tools.is_empty() && custom_tools.is_empty() {
                             translate::from_chat_response(response_id.clone(), &model, chat_resp)

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -1,5 +1,8 @@
 use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    hash::{Hash, Hasher},
+};
 
 use crate::{session::SessionStore, types::*};
 
@@ -22,6 +25,203 @@ pub type CustomToolMap = HashMap<String, CustomToolName>;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TranslateOptions {
     pub opencode_go_compat: bool,
+}
+
+/// Derive a stable fallback session identity when the Responses client does
+/// not provide x-opencode-session. The relay binds this identity to its
+/// response IDs for subsequent previous_response_id requests.
+pub fn opencode_session_id_for_request(req: &ResponsesRequest) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let fingerprint = match &req.input {
+        ResponsesInput::Text(text) => Some(text.clone()),
+        ResponsesInput::Messages(items) => items.iter().find_map(|item| {
+            (item.get("type").and_then(Value::as_str) == Some("message"))
+                .then(|| serde_json::to_string(item).ok())
+                .flatten()
+        }),
+    };
+
+    if let Some(fingerprint) = fingerprint {
+        fingerprint.hash(&mut hasher);
+        format!("codex-relay-{:016x}", hasher.finish())
+    } else {
+        format!("codex-relay-{}", uuid::Uuid::new_v4().simple())
+    }
+}
+
+/// Normalize a Responses payload before forwarding it to OpenCode Go's
+/// native Responses endpoint. Returns (orphan outputs normalized, schema refs
+/// stripped, unsupported tool fields stripped).
+pub fn normalize_opencode_go_responses_payload(payload: &mut Value) -> (usize, usize, usize) {
+    let normalized_outputs = payload
+        .get_mut("input")
+        .and_then(Value::as_array_mut)
+        .map(|items| {
+            let mut changed = 0;
+            for item in items {
+                let normalized = normalize_opencode_go_input_item(item);
+                if normalized != *item {
+                    changed += 1;
+                    *item = normalized;
+                }
+            }
+            changed
+        })
+        .unwrap_or(0);
+    let mut stripped_fields = payload
+        .get_mut("tools")
+        .and_then(Value::as_array_mut)
+        .map(normalize_opencode_go_tools)
+        .unwrap_or(0);
+    let stripped_refs = payload
+        .get_mut("tools")
+        .and_then(Value::as_array_mut)
+        .map(|tools| strip_tool_schema_refs(tools))
+        .unwrap_or(0);
+    stripped_fields += payload
+        .get_mut("tools")
+        .and_then(Value::as_array_mut)
+        .map(|tools| strip_opencode_go_unsupported_tool_fields(tools))
+        .unwrap_or(0);
+    if payload
+        .get("reasoning")
+        .and_then(Value::as_object)
+        .and_then(|reasoning| reasoning.get("effort"))
+        .and_then(Value::as_str)
+        == Some("none")
+    {
+        payload
+            .as_object_mut()
+            .and_then(|object| object.remove("reasoning"));
+        stripped_fields += 1;
+    }
+    (normalized_outputs, stripped_refs, stripped_fields)
+}
+
+fn normalize_opencode_go_tools(tools: &mut Vec<Value>) -> usize {
+    let original = std::mem::take(tools);
+    let mut changed = 0;
+    for tool in original {
+        match tool.get("type").and_then(Value::as_str).unwrap_or("") {
+            "function" => {
+                let mut tool = tool;
+                bound_native_tool_name(&mut tool);
+                tools.push(tool);
+            }
+            "web_search_preview" => tools.push(tool),
+            "custom" => {
+                if let Some(function) = custom_tool_as_function(tool, None) {
+                    tools.push(function);
+                    changed += 1;
+                }
+            }
+            "namespace" => {
+                let namespace = tool.get("name").and_then(Value::as_str).unwrap_or("");
+                for child in tool
+                    .get("tools")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                {
+                    match child.get("type").and_then(Value::as_str).unwrap_or("") {
+                        "function" => {
+                            let mut function = child.clone();
+                            prefix_native_tool_name(&mut function, namespace);
+                            tools.push(function);
+                            changed += 1;
+                        }
+                        "custom" => {
+                            if let Some(function) =
+                                custom_tool_as_function(child.clone(), Some(namespace))
+                            {
+                                tools.push(function);
+                                changed += 1;
+                            }
+                        }
+                        _ => changed += 1,
+                    }
+                }
+            }
+            _ => changed += 1,
+        }
+    }
+    changed
+}
+
+fn custom_tool_as_function(mut tool: Value, namespace: Option<&str>) -> Option<Value> {
+    let object = tool.as_object_mut()?;
+    let original_name = object.get("name")?.as_str()?.to_owned();
+    let argument_field = custom_argument_field(&original_name);
+    let full_name = namespace.map_or(original_name.clone(), |namespace| {
+        chat_function_name_for_namespace_tool(namespace, &original_name)
+    });
+    object.insert("type".into(), Value::String("function".into()));
+    object.insert(
+        "name".into(),
+        Value::String(bound_native_tool_name_value(&full_name)),
+    );
+    object.remove("format");
+    object.remove("input_format");
+    if !object.contains_key("parameters") {
+        object.insert(
+            "parameters".into(),
+            json!({
+                "type": "object",
+                "properties": {argument_field: {"type": "string"}},
+                "required": [argument_field]
+            }),
+        );
+    }
+    Some(tool)
+}
+
+fn prefix_native_tool_name(tool: &mut Value, namespace: &str) {
+    let Some(object) = tool.as_object_mut() else {
+        return;
+    };
+    let Some(name) = object.get("name").and_then(Value::as_str) else {
+        return;
+    };
+    object.insert(
+        "name".into(),
+        Value::String(bound_native_tool_name_value(
+            &chat_function_name_for_namespace_tool(namespace, name),
+        )),
+    );
+}
+
+fn bound_native_tool_name(tool: &mut Value) {
+    let Some(object) = tool.as_object_mut() else {
+        return;
+    };
+    let Some(name) = object.get("name").and_then(Value::as_str) else {
+        return;
+    };
+    object.insert(
+        "name".into(),
+        Value::String(bound_native_tool_name_value(name)),
+    );
+}
+
+fn bound_native_tool_name_value(name: &str) -> String {
+    const MAX_NAME_BYTES: usize = 64;
+    if name.len() <= MAX_NAME_BYTES {
+        return name.to_owned();
+    }
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    name.hash(&mut hasher);
+    let suffix = format!("-{:08x}", hasher.finish() as u32);
+    let prefix_len = MAX_NAME_BYTES - suffix.len();
+    let prefix: String = name.chars().take(prefix_len).collect();
+    format!("{prefix}{suffix}")
+}
+
+fn strip_opencode_go_unsupported_tool_fields(tools: &mut [Value]) -> usize {
+    tools
+        .iter_mut()
+        .filter(|tool| tool.get("type").and_then(Value::as_str) != Some("web_search_preview"))
+        .filter_map(|tool| tool.as_object_mut()?.remove("search_content_types"))
+        .count()
 }
 
 /// Reject tool declarations that collapse to the same Chat Completions name.
@@ -345,6 +545,27 @@ pub fn to_chat_request_with_options(
 }
 
 fn normalize_opencode_go_input_item(item: &Value) -> Value {
+    if item.get("type").and_then(Value::as_str) == Some("custom_tool_call") {
+        let name = item.get("name").and_then(Value::as_str).unwrap_or("tool");
+        let argument_field = custom_argument_field(name);
+        let input = item
+            .get("input")
+            .cloned()
+            .unwrap_or_else(|| Value::String(String::new()));
+        return json!({
+            "type": "function_call",
+            "call_id": item.get("call_id").cloned().unwrap_or(Value::Null),
+            "name": name,
+            "arguments": json!({argument_field: input}).to_string(),
+        });
+    }
+    if item.get("type").and_then(Value::as_str) == Some("custom_tool_call_output") {
+        let mut normalized = item.clone();
+        if let Some(object) = normalized.as_object_mut() {
+            object.insert("type".into(), Value::String("function_call_output".into()));
+        }
+        return normalized;
+    }
     let is_orphan_output = item.get("type").and_then(Value::as_str) == Some("function_call_output")
         && item
             .get("call_id")

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -19,6 +19,11 @@ pub struct CustomToolName {
 
 pub type CustomToolMap = HashMap<String, CustomToolName>;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TranslateOptions {
+    pub opencode_go_compat: bool,
+}
+
 /// Reject tool declarations that collapse to the same Chat Completions name.
 /// The `namespace-name` encoding is not reversible on its own; silently
 /// overwriting one identity could route a call to the wrong namespace and, for
@@ -47,6 +52,16 @@ pub fn to_chat_request(
     req: &ResponsesRequest,
     history: Vec<ChatMessage>,
     sessions: &SessionStore,
+) -> ChatRequest {
+    to_chat_request_with_options(req, history, sessions, TranslateOptions::default())
+}
+
+/// Convert a Responses API request with optional provider-specific workarounds.
+pub fn to_chat_request_with_options(
+    req: &ResponsesRequest,
+    history: Vec<ChatMessage>,
+    sessions: &SessionStore,
+    options: TranslateOptions,
 ) -> ChatRequest {
     let mut messages = history;
 
@@ -106,6 +121,12 @@ pub fn to_chat_request(
             messages.push(msg);
         }
         ResponsesInput::Messages(items) => {
+            let normalized_items: Vec<Value> = if options.opencode_go_compat {
+                items.iter().map(normalize_opencode_go_input_item).collect()
+            } else {
+                items.clone()
+            };
+            let items = &normalized_items;
             // Request-scoped custom tool map so replayed custom_tool_call items
             // are wrapped with the same argument field the tool declared.
             let custom_tools = custom_tool_map(&req.tools);
@@ -320,6 +341,56 @@ pub fn to_chat_request(
             .as_ref()
             .and_then(|reasoning| reasoning.effort.clone()),
         stream: req.stream,
+    }
+}
+
+fn normalize_opencode_go_input_item(item: &Value) -> Value {
+    let is_orphan_output = item.get("type").and_then(Value::as_str) == Some("function_call_output")
+        && item
+            .get("call_id")
+            .and_then(Value::as_str)
+            .is_none_or(str::is_empty);
+    if !is_orphan_output {
+        return item.clone();
+    }
+
+    let name = item.get("name").and_then(Value::as_str).unwrap_or("tool");
+    let namespace = item
+        .get("namespace")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty());
+    let label = namespace.map_or_else(|| name.to_string(), |ns| format!("{ns}/{name}"));
+    let output = response_output_text(item.get("output"));
+    json!({
+        "type": "message",
+        "role": "developer",
+        "content": format!("[{label} output]\n{output}"),
+    })
+}
+
+fn response_output_text(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::String(text)) => text.clone(),
+        Some(value) => value.to_string(),
+        None => String::new(),
+    }
+}
+
+/// Remove `$ref` schema nodes from function tools for providers that reject
+/// recursive or otherwise unsupported JSON Schema references.
+pub fn strip_tool_schema_refs(tools: &mut [Value]) -> usize {
+    tools.iter_mut().map(strip_schema_refs).sum()
+}
+
+fn strip_schema_refs(value: &mut Value) -> usize {
+    match value {
+        Value::Object(object) if object.contains_key("$ref") => {
+            *value = Value::Object(serde_json::Map::new());
+            1
+        }
+        Value::Object(object) => object.values_mut().map(strip_schema_refs).sum(),
+        Value::Array(items) => items.iter_mut().map(strip_schema_refs).sum(),
+        _ => 0,
     }
 }
 

--- a/tests/compat_codex_0_128.rs
+++ b/tests/compat_codex_0_128.rs
@@ -20,7 +20,9 @@
 //! Live end-to-end coverage against real DeepSeek is in `compat_deepseek_live.rs`.
 
 use codex_relay::session::SessionStore;
-use codex_relay::translate::to_chat_request;
+use codex_relay::translate::{
+    strip_tool_schema_refs, to_chat_request, to_chat_request_with_options, TranslateOptions,
+};
 use codex_relay::types::ResponsesRequest;
 use serde_json::Value;
 use std::path::PathBuf;
@@ -129,4 +131,51 @@ fn unknown_top_level_fields_dont_break_parse() {
     // (Negative coverage — fixture::with_namespace_tool has a few of them.)
     let req = fixture("with_namespace_tool.json");
     assert_eq!(req.model, "deepseek-v4-pro");
+}
+
+#[test]
+fn opencode_go_compat_normalizes_orphan_tool_output() {
+    let req: ResponsesRequest = serde_json::from_value(serde_json::json!({
+        "model": "muse-spark-1.3-contributor",
+        "input": [{
+            "type": "function_call_output",
+            "namespace": "browser",
+            "name": "open",
+            "output": {"text": "done"}
+        }]
+    }))
+    .unwrap();
+
+    let default_chat = to_chat_request(&req, Vec::new(), &SessionStore::new());
+    assert_eq!(default_chat.messages[0].role, "tool");
+    assert_eq!(default_chat.messages[0].tool_call_id.as_deref(), Some(""));
+
+    let chat = to_chat_request_with_options(
+        &req,
+        Vec::new(),
+        &SessionStore::new(),
+        TranslateOptions {
+            opencode_go_compat: true,
+        },
+    );
+    assert_eq!(chat.messages[0].role, "system");
+    assert_eq!(
+        chat.messages[0].text_content(),
+        "[browser/open output]\n{\"text\":\"done\"}"
+    );
+    assert!(chat.messages[0].tool_call_id.is_none());
+}
+
+#[test]
+fn opencode_go_compat_strips_tool_schema_refs() {
+    let mut tools = vec![serde_json::json!({
+        "type": "function",
+        "name": "recursive",
+        "parameters": {"properties": {"child": {"$ref": "#/$defs/Node"}}}
+    })];
+    assert_eq!(strip_tool_schema_refs(&mut tools), 1);
+    assert_eq!(
+        tools[0]["parameters"]["properties"]["child"],
+        serde_json::json!({})
+    );
 }

--- a/tests/compat_codex_0_128.rs
+++ b/tests/compat_codex_0_128.rs
@@ -21,6 +21,7 @@
 
 use codex_relay::session::SessionStore;
 use codex_relay::translate::{
+    normalize_opencode_go_responses_payload, opencode_session_id_for_request,
     strip_tool_schema_refs, to_chat_request, to_chat_request_with_options, TranslateOptions,
 };
 use codex_relay::types::ResponsesRequest;
@@ -177,5 +178,67 @@ fn opencode_go_compat_strips_tool_schema_refs() {
     assert_eq!(
         tools[0]["parameters"]["properties"]["child"],
         serde_json::json!({})
+    );
+}
+
+#[test]
+fn opencode_session_fallback_is_stable_for_the_same_first_message() {
+    let first: ResponsesRequest = serde_json::from_value(serde_json::json!({
+        "model": "muse-spark-1.3-contributor",
+        "input": "hello"
+    }))
+    .unwrap();
+    let second: ResponsesRequest = serde_json::from_value(serde_json::json!({
+        "model": "muse-spark-1.3-contributor",
+        "input": "hello"
+    }))
+    .unwrap();
+
+    assert_eq!(
+        opencode_session_id_for_request(&first),
+        opencode_session_id_for_request(&second)
+    );
+}
+
+#[test]
+fn opencode_go_compat_strips_invalid_search_content_types() {
+    let mut payload = serde_json::json!({
+        "input": "hello",
+        "tools": [{
+            "type": "web_search",
+            "search_content_types": ["text"]
+        }]
+    });
+
+    let (_, _, stripped_fields) = normalize_opencode_go_responses_payload(&mut payload);
+    assert_eq!(stripped_fields, 1);
+    assert!(payload["tools"][0].get("search_content_types").is_none());
+}
+
+#[test]
+fn opencode_go_compat_strips_unsupported_none_reasoning_effort() {
+    let mut payload = serde_json::json!({
+        "input": "hello",
+        "reasoning": {"effort": "none"}
+    });
+
+    let (_, _, stripped_fields) = normalize_opencode_go_responses_payload(&mut payload);
+    assert_eq!(stripped_fields, 1);
+    assert!(payload.get("reasoning").is_none());
+}
+
+#[test]
+fn opencode_go_compat_converts_custom_tools_to_function_tools() {
+    let mut payload = serde_json::json!({
+        "input": "hello",
+        "tools": [{"type": "custom", "name": "apply_patch"}]
+    });
+
+    let (_, _, stripped_fields) = normalize_opencode_go_responses_payload(&mut payload);
+    assert_eq!(stripped_fields, 1);
+    assert_eq!(payload["tools"][0]["type"], "function");
+    assert_eq!(
+        payload["tools"][0]["parameters"]["properties"]["patch"]["type"],
+        "string"
     );
 }


### PR DESCRIPTION
## Summary

- Add `--opencode-go-compat` and `CODEX_RELAY_OPENCODE_GO_COMPAT` as an opt-in compatibility feature.
- Normalize orphan `function_call_output` items before Responses to Chat Completions translation.
- Strip unsupported tool-schema `$ref` nodes only when the feature is enabled.
- Replace the unlimited inbound body setting with a configurable 64 MiB default cap.
- Add offline Codex wire-shape regression coverage and configuration documentation.

## Verification

- `cargo test` passes: 148 library tests, 178 binary tests, 6 Codex compatibility tests, 5 translation tests, and 40 regression tests.
- Live provider tests remain ignored and no external API calls are made by the test suite.

## Context

This was reproduced against OpenCode Go using Codex Responses requests. The compatibility behavior is deliberately opt-in because schema reference removal is provider-specific and can change tool semantics for other upstreams.